### PR TITLE
perf: improve performance of ringbuffer between vmm and kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "bincode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad1fa75f77bbd06f187540aa1d70ca50b80b27ce85e7f41c0ce7ff42b34ed3b"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1cef5dd4a4457dd11529e743d18ba4fabbd5f20b6895f4c865cb257337dcf9f"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitfield-struct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +128,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "libc",
  "log",
  "macros",
@@ -450,6 +471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "unty"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88342087869553c259588a3ec9ca73ce9b2d538b7051ba5789ff236b6c129"
+
+[[package]]
 name = "user"
 version = "0.1.0"
 dependencies = [
@@ -461,6 +488,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vmm"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,6 +14,7 @@ cache = []
 log = "0.4.22"
 snafu = { version="0.8.5", default-features=false }
 macros = { path = "../macros", optional=true }
+bincode = { version = "2.0.0", features = ["alloc", "derive", "bincode_derive"], default-features = false }
 
 [dev-dependencies]
 libc = "0.2.164"

--- a/common/src/buddy.rs
+++ b/common/src/buddy.rs
@@ -1050,6 +1050,7 @@ mod tests {
     }
 
     #[bench]
+    #[ignore]
     fn bench_contended_allocate_free_no_cache(b: &mut Bencher) {
         let mut region: Box<[u8; 0x100000000]> = unsafe { Box::new_zeroed().assume_init() };
         let mut allocator = BuddyAllocator::new(&mut *region);

--- a/common/src/message.rs
+++ b/common/src/message.rs
@@ -19,6 +19,7 @@ pub enum Message {
     Drop(Handle),
     ReadBlob(BlobHandle),
     BlobContents { ptr: usize, len: usize },
+    Exit,
 }
 
 pub type RawHandle = usize;

--- a/common/src/message.rs
+++ b/common/src/message.rs
@@ -14,6 +14,7 @@ pub enum Message {
     CreateThunk(BlobHandle),
     Run(ThunkHandle),
     Apply(LambdaHandle, Handle),
+    ApplyAndRun(LambdaHandle, Handle),
     Created(Handle),
     Drop(Handle),
     Exit,

--- a/common/src/message.rs
+++ b/common/src/message.rs
@@ -1,52 +1,34 @@
 extern crate alloc;
 
+use bincode::{Decode, Encode};
+
 use crate::{
     ringbuffer::{RingBufferEndPoint, RingBufferError, RingBufferReceiver, RingBufferSender},
     BuddyAllocator,
 };
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u8)]
-enum OpCode {
-    CreateBlob = 0,
-    CreateTree = 1,
-    CreateThunk = 2,
-    RunThunk = 3,
-    Apply = 4,
-    Reply = 5,
-    Drop = 6,
-    ReadBlob = 7,
-    BlobContents = 8,
-}
-
-impl TryFrom<u8> for OpCode {
-    type Error = &'static str;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            _ if value == OpCode::CreateBlob as u8 => Ok(OpCode::CreateBlob),
-            _ if value == OpCode::CreateTree as u8 => Ok(OpCode::CreateTree),
-            _ if value == OpCode::CreateThunk as u8 => Ok(OpCode::CreateThunk),
-            _ if value == OpCode::RunThunk as u8 => Ok(OpCode::RunThunk),
-            _ if value == OpCode::Apply as u8 => Ok(OpCode::Apply),
-            _ if value == OpCode::Reply as u8 => Ok(OpCode::Reply),
-            _ if value == OpCode::Drop as u8 => Ok(OpCode::Drop),
-            _ if value == OpCode::ReadBlob as u8 => Ok(OpCode::ReadBlob),
-            _ if value == OpCode::BlobContents as u8 => Ok(OpCode::BlobContents),
-            _ => Err("Invalid raw u8 for OpCode"),
-        }
-    }
+#[derive(Encode, Decode, Debug)]
+pub enum Message {
+    CreateBlob { ptr: usize, len: usize },
+    CreateTree { ptr: usize, len: usize },
+    CreateThunk(BlobHandle),
+    Run(ThunkHandle),
+    Apply(LambdaHandle, Handle),
+    Created(Handle),
+    Drop(Handle),
+    ReadBlob(BlobHandle),
+    BlobContents { ptr: usize, len: usize },
 }
 
 pub type RawHandle = usize;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BlobHandle(RawHandle);
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct TreeHandle(RawHandle);
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct LambdaHandle(RawHandle);
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ThunkHandle(RawHandle);
 
 impl BlobHandle {
@@ -95,7 +77,7 @@ impl TryFrom<u8> for HandleType {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Handle {
     Blob(BlobHandle),
     Tree(TreeHandle),
@@ -106,17 +88,6 @@ pub enum Handle {
 pub trait ArcaHandle: Into<Handle> + Copy {}
 
 impl Handle {
-    fn parse(buf: &[u8; 9]) -> Self {
-        let handletype = HandleType::try_from(buf[0]).expect("");
-        let offset = usize::from_ne_bytes(buf[1..9].try_into().unwrap());
-        match handletype {
-            HandleType::Blob => Self::Blob(BlobHandle(offset)),
-            HandleType::Tree => Self::Tree(TreeHandle(offset)),
-            HandleType::Lambda => Self::Lambda(LambdaHandle(offset)),
-            HandleType::Thunk => Self::Thunk(ThunkHandle(offset)),
-        }
-    }
-
     pub fn to_raw(&self) -> usize {
         match self {
             Handle::Blob(BlobHandle(h))
@@ -124,21 +95,6 @@ impl Handle {
             | Handle::Lambda(LambdaHandle(h))
             | Handle::Thunk(ThunkHandle(h)) => *h,
         }
-    }
-
-    fn serialize(self) -> [u8; 9] {
-        let mut result: [u8; 9] = [0; 9];
-        result[0] = match &self {
-            Handle::Blob(_) => HandleType::Blob as u8,
-            Handle::Tree(_) => HandleType::Tree as u8,
-            Handle::Lambda(_) => HandleType::Lambda as u8,
-            Handle::Thunk(_) => HandleType::Thunk as u8,
-        };
-
-        let sub: &mut [u8; 8] = (&mut result[1..9]).try_into().unwrap();
-        *sub = self.to_raw().to_ne_bytes();
-
-        result
     }
 
     pub fn to_offset<T: Into<Handle>>(x: T) -> usize {
@@ -176,398 +132,65 @@ impl ArcaHandle for TreeHandle {}
 impl ArcaHandle for LambdaHandle {}
 impl ArcaHandle for ThunkHandle {}
 
-#[derive(Debug)]
-pub enum Message {
-    CreateBlobMessage {
-        ptr: usize,
-        size: usize,
-    },
-    CreateTreeMessage {
-        ptr: usize,
-        size: usize,
-    },
-    CreateThunkMessage {
-        handle: BlobHandle,
-    },
-    RunThunkMessage {
-        handle: ThunkHandle,
-    },
-    ApplyMessage {
-        lambda_handle: LambdaHandle,
-        arg_handle: Handle,
-    },
-    ReplyMessage {
-        handle: Handle,
-    },
-    DropMessage {
-        handle: Handle,
-    },
-    ReadBlobMessage {
-        handle: BlobHandle,
-    },
-    BlobContentsMessage {
-        ptr: usize,
-        size: usize,
-    },
-}
-
-impl Message {
-    fn opcode(&self) -> OpCode {
-        match &self {
-            Message::CreateBlobMessage { .. } => OpCode::CreateBlob,
-            Message::CreateTreeMessage { .. } => OpCode::CreateTree,
-            Message::CreateThunkMessage { .. } => OpCode::CreateThunk,
-            Message::RunThunkMessage { .. } => OpCode::RunThunk,
-            Message::ApplyMessage { .. } => OpCode::Apply,
-            Message::ReplyMessage { .. } => OpCode::Reply,
-            Message::DropMessage { .. } => OpCode::Drop,
-            Message::ReadBlobMessage { .. } => OpCode::ReadBlob,
-            Message::BlobContentsMessage { .. } => OpCode::BlobContents,
-        }
-    }
-
-    fn parse(op: &OpCode, buf: &[u8; 18]) -> Option<Message> {
-        match op {
-            OpCode::CreateBlob | OpCode::CreateTree | OpCode::BlobContents => {
-                let left: &[u8; 8] = buf[0..8].try_into().expect("split slice with wrong length");
-                let right: &[u8; 8] = buf[8..16]
-                    .try_into()
-                    .expect("split slice with wrong length");
-                let left = usize::from_ne_bytes(*left);
-                let right = usize::from_ne_bytes(*right);
-
-                match op {
-                    OpCode::CreateBlob => Some(Message::CreateBlobMessage {
-                        ptr: left,
-                        size: right,
-                    }),
-                    OpCode::CreateTree => Some(Message::CreateTreeMessage {
-                        ptr: left,
-                        size: right,
-                    }),
-                    OpCode::BlobContents => Some(Message::BlobContentsMessage {
-                        ptr: left,
-                        size: right,
-                    }),
-                    _ => unreachable!(),
-                }
-            }
-            _ => {
-                let left: &[u8; 9] = buf[0..9].try_into().expect("split slice with wrong length");
-                let left = Handle::parse(left);
-
-                match op {
-                    OpCode::CreateThunk => {
-                        if let Handle::Blob(b) = left {
-                            Some(Message::CreateThunkMessage { handle: b })
-                        } else {
-                            None
-                        }
-                    }
-                    OpCode::ReadBlob => {
-                        if let Handle::Blob(b) = left {
-                            Some(Message::ReadBlobMessage { handle: b })
-                        } else {
-                            None
-                        }
-                    }
-                    OpCode::RunThunk => {
-                        if let Handle::Thunk(t) = left {
-                            Some(Message::RunThunkMessage { handle: t })
-                        } else {
-                            None
-                        }
-                    }
-                    OpCode::Apply => {
-                        if let Handle::Lambda(l) = left {
-                            let right: &[u8; 9] = buf[9..18]
-                                .try_into()
-                                .expect("split slice with wrong length");
-                            let right = Handle::parse(right);
-                            Some(Message::ApplyMessage {
-                                lambda_handle: l,
-                                arg_handle: right,
-                            })
-                        } else {
-                            None
-                        }
-                    }
-                    OpCode::Reply => Some(Message::ReplyMessage { handle: left }),
-                    OpCode::Drop => Some(Message::DropMessage { handle: left }),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    }
-
-    fn msg_size(op: OpCode) -> usize {
-        match op {
-            OpCode::CreateBlob => 16,
-            OpCode::CreateTree => 16,
-            OpCode::CreateThunk => 9,
-            OpCode::RunThunk => 9,
-            OpCode::Apply => 18,
-            OpCode::Reply => 9,
-            OpCode::Drop => 9,
-            OpCode::ReadBlob => 9,
-            OpCode::BlobContents => 16,
-        }
-    }
-}
-
-struct MessageParser<'a> {
-    pending_opcode: Option<OpCode>,
-    pending_opcode_buf: [u8; 1],
-    pending_payload: [u8; 18],
-    pending_payload_offset: usize,
-    expected_payload_size: usize,
-    rb: RingBufferReceiver<'a>,
-}
-
-impl<'a> MessageParser<'a> {
-    fn new(rb: RingBufferReceiver<'a>) -> MessageParser<'a> {
-        Self {
-            pending_opcode: None,
-            pending_opcode_buf: [0; 1],
-            pending_payload: [0; 18],
-            pending_payload_offset: 0,
-            expected_payload_size: 0,
-            rb,
-        }
-    }
-
-    // Read exactly once
-    fn read(&mut self) -> Result<Option<Message>, RingBufferError> {
-        match &self.pending_opcode {
-            None => match self.rb.read(&mut self.pending_opcode_buf) {
-                Ok(_) => {
-                    self.pending_opcode = Some(
-                        OpCode::try_from(self.pending_opcode_buf[0])
-                            .expect("Failed to parse OpCode"),
-                    );
-                    self.expected_payload_size = Message::msg_size(self.pending_opcode.unwrap());
-                    Ok(None)
-                }
-                Err(e) => Err(e),
-            },
-            Some(op) => {
-                match self.rb.read(
-                    &mut self.pending_payload
-                        [self.pending_payload_offset..self.expected_payload_size],
-                ) {
-                    Ok(n) => {
-                        self.pending_payload_offset += n;
-                        // Check whether end of message
-                        if self.pending_payload_offset == self.expected_payload_size {
-                            let result = Message::parse(op, &self.pending_payload);
-
-                            // Reset variables
-                            self.pending_payload_offset = 0;
-                            self.pending_opcode = None;
-
-                            match result {
-                                Some(msg) => Ok(Some(msg)),
-                                None => Err(RingBufferError::ParseError),
-                            }
-                        } else {
-                            Ok(None)
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-        }
-    }
-
-    fn read_one(&mut self) -> Result<Message, RingBufferError> {
-        loop {
-            match self.read() {
-                Ok(Some(m)) => {
-                    return Ok(m);
-                }
-                _ => core::hint::spin_loop(),
-            }
-        }
-    }
-
-    pub fn allocator(&self) -> &'a BuddyAllocator<'a> {
-        self.rb.allocator()
-    }
-}
-
-struct MessageSerializer<'a> {
-    opcode_written: bool,
-    pending_opcode: [u8; 1],
-    pending_payload: [u8; 18],
-    pending_payload_offset: usize,
-    pending_payload_size: usize,
-    rb: RingBufferSender<'a>,
-}
-
-impl<'a> MessageSerializer<'a> {
-    fn new(rb: RingBufferSender<'a>) -> MessageSerializer<'a> {
-        Self {
-            opcode_written: true,
-            pending_opcode: [0; 1],
-            pending_payload: [0; 18],
-            pending_payload_offset: 0,
-            pending_payload_size: 0,
-            rb,
-        }
-    }
-
-    fn loadable(&self) -> bool {
-        self.opcode_written && self.pending_payload_offset == self.pending_payload_size
-    }
-
-    fn serialize(&mut self, msg: Message) {
-        match msg {
-            Message::CreateBlobMessage { ptr: l, size: r }
-            | Message::CreateTreeMessage { ptr: l, size: r } => {
-                let (left, right) = self.pending_payload.split_at_mut(8);
-                let left: &mut [u8; 8] = left.try_into().expect("split slice with wrong length");
-                let right: &mut [u8; 8] = (&mut right[0..8])
-                    .try_into()
-                    .expect("split slice with wrong length");
-
-                *left = usize::to_ne_bytes(l);
-                *right = usize::to_ne_bytes(r);
-            }
-            Message::ApplyMessage {
-                lambda_handle: l,
-                arg_handle: r,
-            } => {
-                let (left, right) = self.pending_payload.split_at_mut(9);
-                let left: &mut [u8; 9] = left.try_into().expect("split slice with wrong length");
-                let right: &mut [u8; 9] = right.try_into().expect("split slice with wrong length");
-
-                *left = Handle::serialize(Handle::Lambda(l));
-                *right = Handle::serialize(r);
-            }
-            Message::CreateThunkMessage { handle: b } => {
-                let left: &mut [u8; 9] = (&mut self.pending_payload[0..9]).try_into().unwrap();
-                *left = Handle::serialize(Handle::Blob(b))
-            }
-            Message::RunThunkMessage { handle: t } => {
-                let left: &mut [u8; 9] = (&mut self.pending_payload[0..9]).try_into().unwrap();
-                *left = Handle::serialize(Handle::Thunk(t))
-            }
-            Message::ReplyMessage { handle: h } | Message::DropMessage { handle: h } => {
-                let left: &mut [u8; 9] = (&mut self.pending_payload[0..9]).try_into().unwrap();
-                *left = Handle::serialize(h)
-            }
-            Message::ReadBlobMessage { handle: b } => {
-                let left: &mut [u8; 9] = (&mut self.pending_payload[0..9]).try_into().unwrap();
-                *left = Handle::serialize(Handle::Blob(b))
-            }
-            Message::BlobContentsMessage { ptr, size } => {
-                let (left, right) = self.pending_payload.split_at_mut(8);
-                let left: &mut [u8; 8] = left.try_into().expect("split slice with wrong length");
-                let right: &mut [u8; 8] = (&mut right[0..8])
-                    .try_into()
-                    .expect("split slice with wrong length");
-
-                *left = usize::to_ne_bytes(ptr);
-                *right = usize::to_ne_bytes(size);
-            }
-        }
-    }
-
-    fn load(&mut self, msg: Message) -> Result<(), RingBufferError> {
-        if !self.loadable() {
-            return Err(RingBufferError::WouldBlock);
-        }
-
-        self.opcode_written = false;
-        self.pending_opcode[0] = msg.opcode() as u8;
-        self.pending_payload_offset = 0;
-        self.pending_payload_size = Message::msg_size(msg.opcode());
-        self.serialize(msg);
-
-        Ok(())
-    }
-
-    fn write(&mut self) -> Result<(), RingBufferError> {
-        if !self.opcode_written {
-            log::debug!("writing opcode");
-            match self.rb.write(&self.pending_opcode) {
-                Ok(_) => {
-                    self.opcode_written = true;
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            log::debug!("writing message");
-            match self.rb.write(
-                &self.pending_payload[self.pending_payload_offset..self.pending_payload_size],
-            ) {
-                Ok(n) => {
-                    self.pending_payload_offset += n;
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    fn write_all(&mut self) -> Result<(), RingBufferError> {
-        while !self.loadable() {
-            self.write()?;
-        }
-        Ok(())
-    }
-
-    pub fn allocator(&self) -> &'a BuddyAllocator<'a> {
-        self.rb.allocator()
-    }
-}
-
 pub struct Messenger<'a> {
-    serializer: MessageSerializer<'a>,
-    parser: MessageParser<'a>,
+    buffer: [u8; 16],
+    sender: RingBufferSender<'a>,
+    receiver: RingBufferReceiver<'a>,
 }
 
 impl<'a> Messenger<'a> {
     pub fn new(endpoint: RingBufferEndPoint<'a>) -> Self {
         let (sender, receiver) = endpoint.into_sender_receiver();
         Self {
-            serializer: MessageSerializer::new(sender),
-            parser: MessageParser::new(receiver),
+            buffer: [0; 16],
+            sender,
+            receiver,
         }
     }
 
+    pub fn send(&mut self, msg: Message) -> Result<(), RingBufferError> {
+        log::debug!("sending {msg:x?}");
+        let size = bincode::encode_into_slice(msg, &mut self.buffer, bincode::config::standard())
+            .map_err(|_| RingBufferError::ParseError)?;
+        self.sender.write_all(&size.to_ne_bytes())?;
+        let buf = &mut self.buffer[..size];
+        self.sender.write_all(buf)?;
+        Ok(())
+    }
+
     pub fn receive(&mut self) -> Result<Message, RingBufferError> {
-        self.parser.read_one()
+        let mut size: [u8; 8] = [0; 8];
+        self.receiver.read_exact(&mut size)?;
+        let size = usize::from_ne_bytes(size);
+        assert!(size <= self.buffer.len());
+        let buf = &mut self.buffer[..size];
+        self.receiver.read_exact(buf)?;
+        let (decoded, _): (Message, usize) =
+            bincode::decode_from_slice(buf, bincode::config::standard())
+                .map_err(|_| RingBufferError::ParseError)?;
+        Ok(decoded)
     }
 
     pub fn send_and_receive(&mut self, msg: Message) -> Result<Message, RingBufferError> {
         self.send(msg)?;
-        let response = self.parser.read_one()?;
+        let response = self.receive()?;
         log::debug!("received {response:x?}");
         Ok(response)
     }
 
     pub fn send_and_receive_handle(&mut self, msg: Message) -> Result<Handle, RingBufferError> {
         let response = self.send_and_receive(msg)?;
-        let Message::ReplyMessage { handle } = response else {
+        let Message::Created(handle) = response else {
             return Err(RingBufferError::TypeError);
         };
         Ok(handle)
     }
 
-    pub fn send(&mut self, msg: Message) -> Result<(), RingBufferError> {
-        log::debug!("sending {msg:x?}");
-        self.serializer.load(msg)?;
-        self.serializer.write_all()?;
-        Ok(())
-    }
-
     pub fn allocator(&self) -> &'a BuddyAllocator<'a> {
         assert_eq!(
-            self.serializer.allocator() as *const _,
-            self.parser.allocator() as *const _
+            self.sender.allocator() as *const _,
+            self.receiver.allocator() as *const _
         );
-        self.serializer.allocator()
+        self.sender.allocator()
     }
 }

--- a/common/src/ringbuffer.rs
+++ b/common/src/ringbuffer.rs
@@ -132,6 +132,7 @@ impl<'a> RingBuffer<'a> {
             match self.read(buf) {
                 Ok(0) => break,
                 Ok(n) => {
+                    core::hint::spin_loop();
                     buf = &mut buf[n..];
                 }
                 Err(_) => {}
@@ -143,6 +144,7 @@ impl<'a> RingBuffer<'a> {
     fn write_all(&self, mut buf: &[u8]) -> Result<(), RingBufferError> {
         while !buf.is_empty() {
             if let Ok(n) = self.write(buf) {
+                core::hint::spin_loop();
                 buf = &buf[n..]
             }
         }

--- a/common/src/ringbuffer.rs
+++ b/common/src/ringbuffer.rs
@@ -128,10 +128,11 @@ impl<'a> RingBuffer<'a> {
             match self.read(buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    core::hint::spin_loop();
                     buf = &mut buf[n..];
                 }
-                Err(_) => {}
+                Err(_) => {
+                    core::hint::spin_loop();
+                }
             }
         }
         Ok(())
@@ -140,9 +141,9 @@ impl<'a> RingBuffer<'a> {
     fn write_all(&self, mut buf: &[u8]) -> Result<(), RingBufferError> {
         while !buf.is_empty() {
             if let Ok(n) = self.write(buf) {
-                core::hint::spin_loop();
                 buf = &buf[n..]
             }
+            core::hint::spin_loop();
         }
         Ok(())
     }

--- a/kernel/src/client.rs
+++ b/kernel/src/client.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::spinlock::SpinLock;
 use crate::types::Value;
 use common::message::{
-    ArcaHandle, BlobHandle, LambdaHandle, Message, Messenger, ThunkHandle, TreeHandle,
+    BlobHandle, Handle, LambdaHandle, Message, Messenger, ThunkHandle, TreeHandle,
 };
 
 extern crate alloc;
@@ -14,47 +14,48 @@ use alloc::vec::Vec;
 pub static MESSENGER: OnceLock<SpinLock<Messenger>> = OnceLock::new();
 
 fn reply(value: Box<Value>) {
-    let msg = match (&value).as_ref() {
+    let msg = match value.as_ref() {
         Value::Blob(_) => {
             let ptr = Box::into_raw(value);
+            log::info!("sending blob {ptr:p}");
             Message::ReplyMessage {
-                handle: ArcaHandle::BlobHandle(BlobHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
+                handle: Handle::Blob(BlobHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
             }
         }
         Value::Tree(_) => {
             let ptr = Box::into_raw(value);
+            log::info!("sending tree {ptr:p}");
             Message::ReplyMessage {
-                handle: ArcaHandle::TreeHandle(TreeHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
+                handle: Handle::Tree(TreeHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
             }
         }
         Value::Lambda(_) => {
             let ptr = Box::into_raw(value);
+            log::info!("sending lambda {ptr:p}");
             Message::ReplyMessage {
-                handle: ArcaHandle::LambdaHandle(LambdaHandle::new(
-                    PHYSICAL_ALLOCATOR.to_offset(ptr),
-                )),
+                handle: Handle::Lambda(LambdaHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
             }
         }
         Value::Thunk(_) => {
             let ptr = Box::into_raw(value);
+            log::info!("sending thunk {ptr:p}");
             Message::ReplyMessage {
-                handle: ArcaHandle::ThunkHandle(ThunkHandle::new(
-                    PHYSICAL_ALLOCATOR.to_offset(ptr),
-                )),
+                handle: Handle::Thunk(ThunkHandle::new(PHYSICAL_ALLOCATOR.to_offset(ptr))),
             }
         }
         _ => todo!(),
     };
 
-    let _ = MESSENGER.lock().send(msg);
+    MESSENGER.lock().send(msg).unwrap();
 }
 
-fn reconstruct<T: Into<ArcaHandle>>(handle: T) -> Box<Value> {
-    let ptr = PHYSICAL_ALLOCATOR.from_offset::<Value>(ArcaHandle::to_offset(handle));
+fn reconstruct<T: Into<Handle>>(handle: T) -> Box<Value> {
+    let ptr = PHYSICAL_ALLOCATOR.from_offset::<Value>(Handle::to_offset(handle));
     unsafe { Box::from_raw(ptr as *mut Value) }
 }
 
 pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> bool {
+    log::info!("message: {msg:x?}");
     match msg {
         Message::CreateBlobMessage { ptr, size } => {
             let blob: Blob = unsafe {
@@ -63,14 +64,14 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> bool {
                     size,
                 ))
             };
-            reply(Box::new(Value::Blob(blob)));
             log::info!("processed create blob");
+            reply(Box::new(Value::Blob(blob)));
             true
         }
         Message::CreateTreeMessage { ptr, size } => {
-            let vals: Box<[ArcaHandle]> = unsafe {
+            let vals: Box<[Handle]> = unsafe {
                 Box::from_raw(core::ptr::slice_from_raw_parts_mut(
-                    PHYSICAL_ALLOCATOR.from_offset::<ArcaHandle>(ptr) as *mut ArcaHandle,
+                    PHYSICAL_ALLOCATOR.from_offset::<Handle>(ptr),
                     size,
                 ))
             };
@@ -85,7 +86,7 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> bool {
         Message::CreateThunkMessage { handle } => {
             let v = reconstruct(handle);
             match Box::into_inner(v) {
-                Value::Blob(b) => reply(Box::new(Value::Thunk(Thunk::from_elf(&*b)))),
+                Value::Blob(b) => reply(Box::new(Value::Thunk(Thunk::from_elf(&b)))),
                 _ => todo!(),
             };
             log::info!("processed create thunk");
@@ -114,17 +115,17 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> bool {
             true
         }
         Message::DropMessage { handle } => {
-            reconstruct(handle);
-            log::info!("processed drop");
+            let p = reconstruct(handle);
+            core::mem::drop(p);
             false
         }
         _ => todo!(),
     }
 }
 
-pub fn run(cpu: &mut Cpu) -> () {
+pub fn run(cpu: &mut Cpu) {
     loop {
-        let msg = MESSENGER.lock().get_one().ok().expect("Failed to read msg");
+        let msg = MESSENGER.lock().receive().expect("Failed to read msg");
         let cont = process_incoming_message(msg, cpu);
         if !cont {
             return;

--- a/kernel/src/client.rs
+++ b/kernel/src/client.rs
@@ -118,6 +118,14 @@ pub fn process_incoming_message(m: &mut Messenger, msg: Message, cpu: &mut Cpu) 
                 _ => todo!(),
             };
         }
+        Message::ApplyAndRun(lambda, arg) => {
+            let v = reconstruct(lambda.into());
+            let arg = reconstruct(arg);
+            match v {
+                Value::Lambda(lambda) => reply(m, lambda.apply(arg).run(cpu)),
+                _ => todo!(),
+            };
+        }
         Message::Drop(handle) => {
             let p = reconstruct(handle);
             core::mem::drop(p);

--- a/kernel/src/client.rs
+++ b/kernel/src/client.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::spinlock::SpinLock;
 use crate::types::Value;
 use common::message::{
-    BlobHandle, Handle, LambdaHandle, Message, Messenger, NullHandle, ThunkHandle, TreeHandle,
+    BlobHandle, Handle, LambdaHandle, Message, Messenger, ThunkHandle, TreeHandle,
 };
 
 extern crate alloc;
@@ -15,55 +15,65 @@ use alloc::vec::Vec;
 
 pub static MESSENGER: OnceLock<SpinLock<Messenger>> = OnceLock::new();
 
-fn reply(value: Box<Value>) {
-    let msg = match value.as_ref() {
-        Value::Null => {
-            let ptr = Box::into_raw(value);
-            Message::Created(Handle::Null(NullHandle::new(
+fn reply(m: &mut Messenger, value: Value) {
+    let msg = match value {
+        Value::Null => Message::Created(Handle::Null),
+        Value::Blob(blob) => {
+            let ptr = Arc::into_raw(blob);
+            Message::Created(Handle::Blob(BlobHandle {
+                ptr: PHYSICAL_ALLOCATOR.to_offset(ptr),
+                len: ptr.len(),
+            }))
+        }
+        Value::Tree(tree) => {
+            let ptr = Arc::into_raw(tree);
+            Message::Created(Handle::Tree(TreeHandle {
+                ptr: PHYSICAL_ALLOCATOR.to_offset(ptr),
+                len: ptr.len(),
+            }))
+        }
+        Value::Lambda(lambda) => {
+            let ptr = Box::into_raw(lambda.into());
+            Message::Created(Handle::Lambda(LambdaHandle(
                 PHYSICAL_ALLOCATOR.to_offset(ptr),
             )))
         }
-        Value::Blob(_) => {
-            let ptr = Box::into_raw(value);
-            Message::Created(Handle::Blob(BlobHandle::new(
-                PHYSICAL_ALLOCATOR.to_offset(ptr),
-            )))
-        }
-        Value::Tree(_) => {
-            let ptr = Box::into_raw(value);
-            Message::Created(Handle::Tree(TreeHandle::new(
-                PHYSICAL_ALLOCATOR.to_offset(ptr),
-            )))
-        }
-        Value::Lambda(_) => {
-            let ptr = Box::into_raw(value);
-            Message::Created(Handle::Lambda(LambdaHandle::new(
-                PHYSICAL_ALLOCATOR.to_offset(ptr),
-            )))
-        }
-        Value::Thunk(_) => {
-            let ptr = Box::into_raw(value);
-            Message::Created(Handle::Thunk(ThunkHandle::new(
+        Value::Thunk(thunk) => {
+            let ptr = Box::into_raw(thunk.into());
+            Message::Created(Handle::Thunk(ThunkHandle(
                 PHYSICAL_ALLOCATOR.to_offset(ptr),
             )))
         }
         _ => todo!(),
     };
 
-    MESSENGER.lock().send(msg).unwrap();
+    m.send(msg).unwrap();
 }
 
-fn reconstruct<T: Into<Handle>>(handle: T) -> Box<Value> {
-    let ptr = PHYSICAL_ALLOCATOR.from_offset::<Value>(Handle::to_offset(handle));
-    unsafe { Box::from_raw(ptr) }
+fn reconstruct(handle: Handle) -> Value {
+    let allocator = &*PHYSICAL_ALLOCATOR;
+    unsafe {
+        match handle {
+            Handle::Null => Value::Null,
+            Handle::Blob(handle) => Value::Blob(Arc::from_raw(core::ptr::from_raw_parts(
+                allocator.from_offset::<u8>(handle.ptr),
+                handle.len,
+            ))),
+            Handle::Tree(handle) => Value::Tree(Arc::from_raw(core::ptr::from_raw_parts(
+                allocator.from_offset::<Value>(handle.ptr),
+                handle.len,
+            ))),
+            Handle::Lambda(lambda) => {
+                Value::Lambda(*Box::from_raw(allocator.from_offset(lambda.0)))
+            }
+            Handle::Thunk(thunk) => Value::Thunk(*Box::from_raw(allocator.from_offset(thunk.0))),
+        }
+    }
 }
 
-pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> ControlFlow<()> {
+pub fn process_incoming_message(m: &mut Messenger, msg: Message, cpu: &mut Cpu) -> ControlFlow<()> {
     log::debug!("message: {msg:x?}");
     match msg {
-        Message::CreateNull => {
-            reply(Box::new(Value::Null));
-        }
         Message::CreateBlob { ptr, len } => {
             let blob: Blob = unsafe {
                 Arc::from_raw(core::ptr::slice_from_raw_parts(
@@ -71,7 +81,7 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> ControlFlow<()> 
                     len,
                 ))
             };
-            reply(Box::new(Value::Blob(blob)));
+            reply(m, Value::Blob(blob));
         }
         Message::CreateTree { ptr, len } => {
             let vals: Box<[Handle]> = unsafe {
@@ -82,48 +92,35 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> ControlFlow<()> 
             };
             let mut vec = Vec::new();
             for v in vals {
-                vec.push(Box::into_inner(reconstruct(v)));
+                vec.push(reconstruct(v));
             }
-            reply(Box::new(Value::Tree(vec.into())));
+            reply(m, Value::Tree(vec.into()));
         }
         Message::CreateThunk(handle) => {
-            let v = reconstruct(handle);
-            match Box::into_inner(v) {
-                Value::Blob(b) => reply(Box::new(Value::Thunk(Thunk::from_elf(&b)))),
+            let v = reconstruct(handle.into());
+            match v {
+                Value::Blob(b) => reply(m, Value::Thunk(Thunk::from_elf(&b))),
                 _ => todo!(),
             };
         }
         Message::Run(handle) => {
-            let v = reconstruct(handle);
-            match Box::into_inner(v) {
-                Value::Thunk(thunk) => reply(Box::new(thunk.run(cpu))),
+            let v = reconstruct(handle.into());
+            match v {
+                Value::Thunk(thunk) => reply(m, thunk.run(cpu)),
                 _ => todo!(),
             };
         }
         Message::Apply(lambda, arg) => {
-            let v = Box::into_inner(reconstruct(lambda));
-            let arg = Box::into_inner(reconstruct(arg));
+            let v = reconstruct(lambda.into());
+            let arg = reconstruct(arg);
             match v {
-                Value::Lambda(lambda) => reply(Box::new(Value::Thunk(lambda.apply(arg)))),
+                Value::Lambda(lambda) => reply(m, Value::Thunk(lambda.apply(arg))),
                 _ => todo!(),
             };
         }
         Message::Drop(handle) => {
             let p = reconstruct(handle);
             core::mem::drop(p);
-        }
-        Message::ReadBlob(handle) => {
-            let v = reconstruct(handle);
-            match v.as_ref() {
-                Value::Blob(blob) => {
-                    let (ptr, len) = (&raw const blob[0], blob.len());
-                    let ptr = PHYSICAL_ALLOCATOR.to_offset(ptr);
-                    let msg = Message::BlobContents { ptr, len };
-                    MESSENGER.lock().send(msg).unwrap();
-                }
-                _ => todo!(),
-            };
-            core::mem::forget(v);
         }
         Message::Exit => {
             return ControlFlow::Break(());
@@ -135,9 +132,12 @@ pub fn process_incoming_message(msg: Message, cpu: &mut Cpu) -> ControlFlow<()> 
 
 pub fn run(cpu: &mut Cpu) {
     loop {
-        let msg = MESSENGER.lock().receive().expect("Failed to read msg");
-        if process_incoming_message(msg, cpu) == ControlFlow::Break(()) {
-            return;
+        let mut m = MESSENGER.lock();
+        if !m.is_empty() {
+            let msg = m.receive().expect("Failed to read msg");
+            if process_incoming_message(&mut m, msg, cpu) == ControlFlow::Break(()) {
+                return;
+            }
         }
         core::hint::spin_loop();
     }

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -69,7 +69,14 @@ unsafe extern "C" fn isr_entry(registers: &mut IsrRegisterFile) {
     // supervisor mode
     if registers.isr == 0xd {
         if registers.code == 0 {
-            panic!("Supervisor GP @ {:p}!", registers.rip as *mut (),);
+            if let Some((name, offset)) = crate::host::symname(registers.rip as *const ()) {
+                panic!(
+                    "Supervisor GP @ {name}+{offset:#x} ({:p})!",
+                    registers.rip as *mut (),
+                );
+            } else {
+                panic!("Supervisor GP @ {:p}!", registers.rip as *mut (),);
+            }
         } else {
             panic!(
                 "Supervisor GP @ {:p}! faulting segment: {:#x}",

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -97,12 +97,23 @@ unsafe extern "C" fn isr_entry(registers: &mut IsrRegisterFile) {
             registers.rip = escape as usize as u64;
             return;
         }
-        panic!(
-            "unhandled page fault ({:b}) @ {:p} from RIP={:p}:",
-            registers.code,
-            crate::registers::read_cr2() as *const u8,
-            registers.rip as *const u8,
-        );
+        if let Some((name, offset)) = crate::host::symname(registers.rip as *const ()) {
+            panic!(
+                "unhandled page fault ({:b}) @ {:p} from RIP={:p} ({}+{:#x}):",
+                registers.code,
+                crate::registers::read_cr2() as *const u8,
+                registers.rip as *const u8,
+                name,
+                offset
+            );
+        } else {
+            panic!(
+                "unhandled page fault ({:b}) @ {:p} from RIP={:p}:",
+                registers.code,
+                crate::registers::read_cr2() as *const u8,
+                registers.rip as *const u8,
+            );
+        }
     }
     if registers.isr < 32 {
         panic!("unhandled exception: {:x?}", registers);

--- a/kernel/src/kvmclock.rs
+++ b/kernel/src/kvmclock.rs
@@ -73,7 +73,6 @@ fn read_boot_time() -> WallClock {
             let data = *boot_time;
             let v1 = (&raw const ((*boot_time).version)).read_volatile();
             if v0 != v1 || (v0 % 2) != 0 || v0 == 0 {
-                log::info!("partial read");
                 core::arch::x86_64::_mm_pause();
                 continue;
             }
@@ -92,7 +91,6 @@ fn read_current() -> (CpuTimeInfo, u64) {
             let tsc = core::arch::x86_64::_rdtsc();
             let v1 = (&raw const ((*cpu_time).version)).read_volatile();
             if v0 != v1 || (v0 % 2) != 0 || v0 == 0 {
-                log::info!("partial read");
                 core::arch::x86_64::_mm_pause();
                 continue;
             }

--- a/kernel/src/lapic.rs
+++ b/kernel/src/lapic.rs
@@ -147,5 +147,5 @@ pub unsafe fn init() {
 
     lapic.set_initial_count(0x10000); // 1ms
 
-    // lapic.set_initial_count(0x40); // 1us
+    lapic.set_initial_count(0x40); // 1us
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(bigint_helper_methods)]
 #![feature(box_into_inner)]
 #![feature(new_zeroed_alloc)]
+#![feature(ptr_metadata)]
 #![test_runner(crate::testing::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -24,8 +24,6 @@ const INFINITE_ELF: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_USER_infinite"))
 extern "C" fn kmain() {
     let id = kernel::coreid();
 
-    kernel::profile::begin();
-
     if id == 0 {
         log::info!("kmain");
     }
@@ -34,7 +32,9 @@ extern "C" fn kmain() {
     let mut cpu = CPU.borrow_mut();
 
     if id == 0 {
+        kernel::profile::begin();
         client::run(&mut cpu);
+        kernel::profile::end();
     }
 
     // Test trap.rs
@@ -336,8 +336,6 @@ extern "C" fn kmain() {
         );
     }
 
-    kernel::profile::end();
-
     if id == 0 {
         log::info!("most frequent functions:");
         let entries = kernel::profile::entries();
@@ -356,7 +354,7 @@ extern "C" fn kmain() {
         let mut entries = Vec::from_iter(entries);
         entries.sort_by_key(|(_name, count)| *count);
         entries.reverse();
-        for (i, &(ref name, count)) in entries[..16].iter().enumerate() {
+        for (i, &(ref name, count)) in entries.iter().take(8).enumerate() {
             log::info!("\t{i}: {count} - {name}");
         }
     }

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -244,10 +244,10 @@ pub trait HardwarePageTableEntry: Sized + Clone {
                 if descriptor.global() {
                     HardwareUnmappedPage::Global(addr)
                 } else if descriptor.writeable() {
-                    let page = UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let page = UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     HardwareUnmappedPage::UniquePage(page)
                 } else {
-                    let page = SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let page = SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     HardwareUnmappedPage::SharedPage(page)
                 }
             }
@@ -257,11 +257,11 @@ pub trait HardwarePageTableEntry: Sized + Clone {
                 self.clear_unchecked();
                 if descriptor.writeable() {
                     let addr = descriptor.address();
-                    let table = UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let table = UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     HardwareUnmappedPage::UniqueTable(table)
                 } else {
                     let addr = descriptor.address();
-                    let table = SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let table = SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     HardwareUnmappedPage::SharedTable(table)
                 }
             }
@@ -280,13 +280,13 @@ pub trait HardwarePageTableEntry: Sized + Clone {
                     let addr = descriptor.address();
                     if descriptor.writeable() {
                         let page: UniquePage<Self::Page> =
-                            UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                            UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                         let new = page.clone();
                         descriptor.set_address(vm::ka2pa(UniquePage::into_raw(new)));
                         core::mem::forget(page);
                     } else {
                         let page: SharedPage<Self::Page> =
-                            SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                            SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                         let new = page.clone();
                         core::mem::forget(page);
                         core::mem::forget(new);
@@ -300,14 +300,14 @@ pub trait HardwarePageTableEntry: Sized + Clone {
                 if descriptor.writeable() {
                     let addr = descriptor.address();
                     let table: UniquePage<Self::Table> =
-                        UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                        UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     let new = table.clone();
                     descriptor.set_address(vm::ka2pa(UniquePage::into_raw(new)));
                     core::mem::forget(table);
                 } else {
                     let addr = descriptor.address();
                     let table: SharedPage<Self::Table> =
-                        SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                        SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     let table = table.clone();
                     let new = table.clone();
                     core::mem::forget(table);
@@ -401,7 +401,7 @@ pub unsafe trait HardwarePageTable:
     const SIZE: usize;
 
     fn new() -> UniquePage<Self> {
-        unsafe { UniquePage::<Self>::new_zeroed_in(&*PHYSICAL_ALLOCATOR).assume_init() }
+        unsafe { UniquePage::<Self>::new_zeroed_in(&PHYSICAL_ALLOCATOR).assume_init() }
     }
 }
 
@@ -568,7 +568,7 @@ pub struct AugmentedPageTable<T: HardwarePageTable>([ManuallyDrop<T::Entry>; 512
 
 impl<T: HardwarePageTable> AugmentedPageTable<T> {
     pub fn new() -> UniquePage<Self> {
-        unsafe { UniquePage::<Self>::new_zeroed_in(&*PHYSICAL_ALLOCATOR).assume_init() }
+        unsafe { UniquePage::<Self>::new_zeroed_in(&PHYSICAL_ALLOCATOR).assume_init() }
     }
 
     fn set_lower(&mut self, lower: usize) {
@@ -792,10 +792,10 @@ impl<T: HardwarePageTableEntry> AugmentedEntry<T> {
                 if descriptor.global() {
                     AugmentedUnmappedPage::Global(addr)
                 } else if descriptor.writeable() {
-                    let page = UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let page = UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     AugmentedUnmappedPage::UniquePage(page)
                 } else {
-                    let page = SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let page = SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     AugmentedUnmappedPage::SharedPage(page)
                 }
             }
@@ -805,11 +805,11 @@ impl<T: HardwarePageTableEntry> AugmentedEntry<T> {
                 self.0.clear_unchecked();
                 if descriptor.writeable() {
                     let addr = descriptor.address();
-                    let table = UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let table = UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     AugmentedUnmappedPage::UniqueTable(table)
                 } else {
                     let addr = descriptor.address();
-                    let table = SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                    let table = SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     AugmentedUnmappedPage::SharedTable(table)
                 }
             }
@@ -830,13 +830,13 @@ impl<T: HardwarePageTableEntry> Clone for AugmentedEntry<T> {
                     let addr = descriptor.address();
                     if descriptor.writeable() {
                         let page: UniquePage<T::Page> =
-                            UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                            UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                         let new = page.clone();
                         descriptor.set_address(vm::ka2pa(UniquePage::into_raw(new)));
                         core::mem::forget(page);
                     } else {
                         let page: SharedPage<T::Page> =
-                            SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                            SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                         let new = page.clone();
                         core::mem::forget(page);
                         core::mem::forget(new);
@@ -850,14 +850,14 @@ impl<T: HardwarePageTableEntry> Clone for AugmentedEntry<T> {
                 if descriptor.writeable() {
                     let addr = descriptor.address();
                     let table: UniquePage<AugmentedPageTable<T::Table>> =
-                        UniquePage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                        UniquePage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     let new = table.clone();
                     descriptor.set_address(vm::ka2pa(UniquePage::into_raw(new)));
                     core::mem::forget(table);
                 } else {
                     let addr = descriptor.address();
                     let table: SharedPage<AugmentedPageTable<T::Table>> =
-                        SharedPage::from_raw_in(vm::pa2ka(addr), &*PHYSICAL_ALLOCATOR);
+                        SharedPage::from_raw_in(vm::pa2ka(addr), &PHYSICAL_ALLOCATOR);
                     let table = table.clone();
                     let new = table.clone();
                     core::mem::forget(table);

--- a/kernel/src/rsstart.rs
+++ b/kernel/src/rsstart.rs
@@ -109,8 +109,7 @@ unsafe extern "C" fn _start(
         PHYSICAL_ALLOCATOR.set(allocator).unwrap();
 
         let raw_rb_data = Box::from_raw(
-            PHYSICAL_ALLOCATOR.from_offset::<RingBufferEndPointRawData>(ring_buffer_data_ptr)
-                as *mut RingBufferEndPointRawData,
+            PHYSICAL_ALLOCATOR.from_offset::<RingBufferEndPointRawData>(ring_buffer_data_ptr),
         );
         let endpoint = RingBufferEndPoint::from_raw_parts(&raw_rb_data, &PHYSICAL_ALLOCATOR);
         core::mem::forget(raw_rb_data);

--- a/kernel/src/rsstart.rs
+++ b/kernel/src/rsstart.rs
@@ -149,7 +149,6 @@ unsafe extern "C" fn _start(
     core::arch::asm!("sti");
 
     kmain();
-    // core::mem::drop(sync);
 
     crate::shutdown();
 }

--- a/vmm/src/client.rs
+++ b/vmm/src/client.rs
@@ -1,211 +1,223 @@
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
 use common::message::{
-    ArcaHandle, BlobHandle, LambdaHandle, Message, Messenger, ThunkHandle, TreeHandle,
+    ArcaHandle, BlobHandle, Handle, LambdaHandle, Message, Messenger, ThunkHandle, TreeHandle,
 };
 use common::ringbuffer::RingBufferError;
 use common::BuddyAllocator;
 extern crate alloc;
-use alloc::sync::Arc;
-use core::cell::RefCell;
+use common::util::spinlock::SpinLock;
 
-pub struct Ref<'a, T: Into<ArcaHandle>> {
-    handle: Option<T>,
-    msger: Arc<RefCell<Messenger<'a>>>,
+pub struct Client<'a> {
+    messenger: SpinLock<Messenger<'a>>,
+    allocator: &'a BuddyAllocator<'a>,
 }
 
-impl<'a, T: Into<ArcaHandle>> Ref<'a, T> {
-    fn take(&mut self) -> Option<T> {
-        self.handle.take()
-    }
-}
-
-impl<T: Into<ArcaHandle>> Drop for Ref<'_, T> {
-    fn drop(&mut self) {
-        let h = self.handle.take();
-        match h {
-            Some(h) => {
-                let _ = drop_handle(&mut self.msger.borrow_mut(), h);
-            }
-            None => {}
+impl<'a> Client<'a> {
+    pub fn new(messenger: Messenger<'a>) -> Self {
+        let allocator: &'a BuddyAllocator<'a> = messenger.allocator();
+        Client {
+            messenger: SpinLock::new(messenger),
+            allocator,
         }
     }
 }
 
-pub type BlobRef<'a> = Ref<'a, BlobHandle>;
-pub type TreeRef<'a> = Ref<'a, TreeHandle>;
-pub type LambdaRef<'a> = Ref<'a, LambdaHandle>;
-pub type ThunkRef<'a> = Ref<'a, ThunkHandle>;
-
-pub enum ArcaRef<'a> {
-    BlobRef(BlobRef<'a>),
-    TreeRef(TreeRef<'a>),
-    LambdaRef(LambdaRef<'a>),
-    ThunkRef(ThunkRef<'a>),
-}
-
-impl<'a> From<BlobRef<'a>> for ArcaRef<'a> {
-    fn from(value: BlobRef<'a>) -> ArcaRef<'a> {
-        ArcaRef::BlobRef(value)
-    }
-}
-
-impl<'a> From<TreeRef<'a>> for ArcaRef<'a> {
-    fn from(value: TreeRef<'a>) -> ArcaRef<'a> {
-        ArcaRef::TreeRef(value)
-    }
-}
-
-impl<'a> From<LambdaRef<'a>> for ArcaRef<'a> {
-    fn from(value: LambdaRef<'a>) -> ArcaRef<'a> {
-        ArcaRef::LambdaRef(value)
-    }
-}
-
-impl<'a> From<ThunkRef<'a>> for ArcaRef<'a> {
-    fn from(value: ThunkRef<'a>) -> ArcaRef<'a> {
-        ArcaRef::ThunkRef(value)
-    }
-}
-
-impl<'a> ArcaRef<'a> {
-    fn new(handle: ArcaHandle, msger: Arc<RefCell<Messenger<'a>>>) -> Self {
-        match handle {
-            ArcaHandle::BlobHandle(h) => ArcaRef::BlobRef(BlobRef {
-                handle: Some(h),
-                msger,
-            }),
-            ArcaHandle::TreeHandle(h) => ArcaRef::TreeRef(TreeRef {
-                handle: Some(h),
-                msger,
-            }),
-            ArcaHandle::LambdaHandle(h) => ArcaRef::LambdaRef(LambdaRef {
-                handle: Some(h),
-                msger,
-            }),
-            ArcaHandle::ThunkHandle(h) => ArcaRef::ThunkRef(ThunkRef {
-                handle: Some(h),
-                msger,
-            }),
-        }
-    }
-
-    fn take(&mut self) -> Option<ArcaHandle> {
-        match self {
-            ArcaRef::BlobRef(h) => h.take().map(|h| h.into()),
-            ArcaRef::TreeRef(h) => h.take().map(|h| h.into()),
-            ArcaRef::LambdaRef(h) => h.take().map(|h| h.into()),
-            ArcaRef::ThunkRef(h) => h.take().map(|h| h.into()),
-        }
-    }
-}
-
-fn get_reply<'a>(
-    msg: Message,
-    msger: Arc<RefCell<Messenger<'a>>>,
-) -> Result<ArcaRef<'a>, RingBufferError> {
-    match msg {
-        Message::ReplyMessage { handle } => Ok(ArcaRef::new(handle, msger)),
-        _ => Err(RingBufferError::TypeError),
-    }
-}
-
-fn create_blob_internal<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    blob: Arc<[u8], &BuddyAllocator>,
-) -> Result<BlobRef<'a>, RingBufferError> {
-    let (slice_ptr, a) = Arc::into_raw_with_allocator(blob);
-    let (ptr, size) = slice_ptr.to_raw_parts();
-    let ptr = a.to_offset(ptr);
-    let reply = msger
-        .borrow_mut()
-        .get_reply(Message::CreateBlobMessage { ptr, size })?;
-    let reply = get_reply(reply, msger.clone())?;
-    match reply {
-        ArcaRef::BlobRef(b) => Ok(b),
-        _ => Err(RingBufferError::TypeError),
-    }
-}
-
-pub fn create_blob<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    blob: &[u8],
-    allocator: &BuddyAllocator,
-) -> Result<BlobRef<'a>, RingBufferError> {
-    let mut blobbuf = unsafe { Arc::new_uninit_slice_in(blob.len(), allocator).assume_init() };
-    Arc::get_mut(&mut blobbuf).unwrap().copy_from_slice(blob);
-    create_blob_internal(msger, blobbuf)
-}
-
-fn create_tree_internal<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    tree: Box<[ArcaHandle], &BuddyAllocator>,
-) -> Result<TreeRef<'a>, RingBufferError> {
-    let (slice_ptr, a) = Box::into_raw_with_allocator(tree);
-    let (ptr, size) = slice_ptr.to_raw_parts();
-    let ptr = a.to_offset(ptr);
-    let reply = msger
-        .borrow_mut()
-        .get_reply(Message::CreateTreeMessage { ptr, size })?;
-    let reply = get_reply(reply, msger.clone())?;
-    match reply {
-        ArcaRef::TreeRef(t) => Ok(t),
-        _ => Err(RingBufferError::TypeError),
-    }
-}
-
-pub fn create_tree<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    tree: Vec<ArcaRef>,
-    allocator: &BuddyAllocator,
-) -> Result<TreeRef<'a>, RingBufferError> {
-    let mut treebuf = Vec::new_in(allocator);
-    for mut a in tree {
-        treebuf.push(a.take().unwrap());
-    }
-    create_tree_internal(msger, treebuf.into_boxed_slice())
-}
-
-pub fn create_thunk<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    mut blobref: BlobRef,
-) -> Result<ThunkRef<'a>, RingBufferError> {
-    let reply = msger.borrow_mut().get_reply(Message::CreateThunkMessage {
-        handle: blobref.handle.take().unwrap(),
-    })?;
-    let reply = get_reply(reply, msger.clone())?;
-    match reply {
-        ArcaRef::ThunkRef(t) => Ok(t),
-        _ => Err(RingBufferError::TypeError),
-    }
-}
-
-pub fn run_thunk<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    mut thunkref: ThunkRef,
-) -> Result<ArcaRef<'a>, RingBufferError> {
-    let reply = msger.borrow_mut().get_reply(Message::RunThunkMessage {
-        handle: thunkref.handle.take().unwrap(),
-    })?;
-    get_reply(reply, msger.clone())
-}
-
-pub fn apply_lambda<'a>(
-    msger: &Arc<RefCell<Messenger<'a>>>,
-    mut lambdaref: LambdaRef,
-    mut argref: ArcaRef,
-) -> Result<ArcaRef<'a>, RingBufferError> {
-    let reply = msger.borrow_mut().get_reply(Message::ApplyMessage {
-        lambda_handle: lambdaref.handle.take().unwrap(),
-        arg_handle: argref.take().unwrap(),
-    })?;
-    get_reply(reply, msger.clone())
-}
-
-pub fn drop_handle<T: Into<ArcaHandle>>(
-    msger: &mut Messenger,
+pub struct Ref<'a, 'b, T: ArcaHandle>
+where
+    'b: 'a,
+{
     handle: T,
-) -> Result<(), RingBufferError> {
-    let msg = Message::DropMessage {
-        handle: handle.into(),
-    };
-    msger.send(msg)
+    client: &'a Client<'b>,
+}
+
+impl<T: ArcaHandle> Drop for Ref<'_, '_, T> {
+    fn drop(&mut self) {
+        let msg = Message::DropMessage {
+            handle: self.handle.into(),
+        };
+        let mut messenger = self.client.messenger.lock();
+        messenger.send(msg).unwrap();
+    }
+}
+
+pub type BlobRef<'a, 'b> = Ref<'a, 'b, BlobHandle>;
+pub type TreeRef<'a, 'b> = Ref<'a, 'b, TreeHandle>;
+pub type LambdaRef<'a, 'b> = Ref<'a, 'b, LambdaHandle>;
+pub type ThunkRef<'a, 'b> = Ref<'a, 'b, ThunkHandle>;
+
+pub enum ArcaRef<'a, 'b>
+where
+    'b: 'a,
+{
+    Blob(BlobRef<'a, 'b>),
+    Tree(TreeRef<'a, 'b>),
+    Lambda(LambdaRef<'a, 'b>),
+    Thunk(ThunkRef<'a, 'b>),
+}
+
+impl<'a, 'b> From<ArcaRef<'a, 'b>> for Handle
+where
+    'b: 'a,
+{
+    fn from(value: ArcaRef<'a, 'b>) -> Self {
+        match value {
+            ArcaRef::Blob(h) => Handle::Blob(h.handle),
+            ArcaRef::Tree(h) => Handle::Tree(h.handle),
+            ArcaRef::Lambda(h) => Handle::Lambda(h.handle),
+            ArcaRef::Thunk(h) => Handle::Thunk(h.handle),
+        }
+    }
+}
+impl<'a, 'b> From<BlobRef<'a, 'b>> for ArcaRef<'a, 'b>
+where
+    'b: 'a,
+{
+    fn from(value: BlobRef<'a, 'b>) -> ArcaRef<'a, 'b> {
+        ArcaRef::Blob(value)
+    }
+}
+
+impl<'a, 'b> From<TreeRef<'a, 'b>> for ArcaRef<'a, 'b>
+where
+    'b: 'a,
+{
+    fn from(value: TreeRef<'a, 'b>) -> ArcaRef<'a, 'b> {
+        ArcaRef::Tree(value)
+    }
+}
+
+impl<'a, 'b> From<LambdaRef<'a, 'b>> for ArcaRef<'a, 'b>
+where
+    'b: 'a,
+{
+    fn from(value: LambdaRef<'a, 'b>) -> ArcaRef<'a, 'b> {
+        ArcaRef::Lambda(value)
+    }
+}
+
+impl<'a, 'b> From<ThunkRef<'a, 'b>> for ArcaRef<'a, 'b>
+where
+    'b: 'a,
+{
+    fn from(value: ThunkRef<'a, 'b>) -> ArcaRef<'a, 'b> {
+        ArcaRef::Thunk(value)
+    }
+}
+
+impl<'b> Client<'b> {
+    fn make_ref<'a>(&'a self, handle: Handle) -> ArcaRef<'a, 'b>
+    where
+        'b: 'a,
+    {
+        match handle {
+            Handle::Blob(handle) => ArcaRef::Blob(BlobRef {
+                handle,
+                client: self,
+            }),
+            Handle::Tree(handle) => ArcaRef::Tree(TreeRef {
+                handle,
+                client: self,
+            }),
+            Handle::Lambda(handle) => ArcaRef::Lambda(LambdaRef {
+                handle,
+                client: self,
+            }),
+            Handle::Thunk(handle) => ArcaRef::Thunk(ThunkRef {
+                handle,
+                client: self,
+            }),
+        }
+    }
+
+    pub fn create_blob<'a>(&'a self, blob: &[u8]) -> Result<BlobRef<'a, 'b>, RingBufferError>
+    where
+        'b: 'a,
+    {
+        let allocator = self.allocator;
+        let mut buf = Arc::new_uninit_slice_in(blob.len(), allocator);
+        Arc::make_mut(&mut buf).write_copy_of_slice(blob);
+        let buf = unsafe { buf.assume_init() };
+        let (slice, a) = Arc::into_raw_with_allocator(buf);
+        let (ptr, size) = slice.to_raw_parts();
+        let ptr = a.to_offset(ptr);
+        let mut m = self.messenger.lock();
+        if let ArcaRef::Blob(b) =
+            self.make_ref(m.send_and_receive(Message::CreateBlobMessage { ptr, size })?)
+        {
+            Ok(b)
+        } else {
+            Err(RingBufferError::TypeError)
+        }
+    }
+
+    pub fn create_tree<'a>(&'b self, tree: Vec<ArcaRef>) -> Result<TreeRef<'a, 'b>, RingBufferError>
+    where
+        'b: 'a,
+    {
+        let mut new: Vec<ArcaRef, &BuddyAllocator> =
+            Vec::with_capacity_in(tree.len(), self.allocator);
+        for r in tree {
+            new.push(r);
+        }
+        let tree = new.into_boxed_slice();
+
+        let (slice, a) = Box::into_raw_with_allocator(tree);
+        let (ptr, size) = slice.to_raw_parts();
+        let ptr = a.to_offset(ptr);
+        let mut m = self.messenger.lock();
+        if let ArcaRef::Tree(t) =
+            self.make_ref(m.send_and_receive(Message::CreateTreeMessage { ptr, size })?)
+        {
+            Ok(t)
+        } else {
+            Err(RingBufferError::TypeError)
+        }
+    }
+}
+
+impl<'a, 'b> Ref<'a, 'b, ThunkHandle>
+where
+    'b: 'a,
+{
+    pub fn new(blob: BlobRef<'a, 'b>) -> Result<Self, RingBufferError> {
+        let BlobRef { client, handle } = blob;
+        core::mem::forget(blob);
+        let mut m = client.messenger.lock();
+        if let ArcaRef::Thunk(t) =
+            client.make_ref(m.send_and_receive(Message::CreateThunkMessage { handle })?)
+        {
+            Ok(t)
+        } else {
+            Err(RingBufferError::TypeError)
+        }
+    }
+
+    pub fn run(self) -> Result<ArcaRef<'a, 'b>, RingBufferError> {
+        let ThunkRef { client, handle } = self;
+        core::mem::forget(self);
+        let mut m = client.messenger.lock();
+        Ok(client.make_ref(m.send_and_receive(Message::RunThunkMessage { handle })?))
+    }
+}
+
+impl<'a, 'b> Ref<'a, 'b, LambdaHandle>
+where
+    'b: 'a,
+{
+    pub fn apply(self, value: ArcaRef<'a, 'b>) -> Result<ThunkRef<'a, 'b>, RingBufferError> {
+        // assert_eq!(self.client as *const _, value.client as *const _);
+        let LambdaRef { client, handle } = self;
+        core::mem::forget(self);
+        let mut m = client.messenger.lock();
+        if let ArcaRef::Thunk(t) = client.make_ref(m.send_and_receive(Message::ApplyMessage {
+            lambda_handle: handle,
+            arg_handle: value.into(),
+        })?) {
+            Ok(t)
+        } else {
+            Err(RingBufferError::TypeError)
+        }
+    }
 }

--- a/vmm/src/client.rs
+++ b/vmm/src/client.rs
@@ -266,4 +266,14 @@ where
             Err(RingBufferError::TypeError)
         }
     }
+
+    pub fn apply_and_run(self, value: ArcaRef<'a, 'b>) -> Result<ArcaRef<'a, 'b>, RingBufferError> {
+        // assert_eq!(self.client as *const _, value.client as *const _);
+        let LambdaRef { client, handle } = self;
+        core::mem::forget(self);
+        let arg_handle = value.handle();
+        core::mem::forget(value);
+        let mut m = client.messenger.lock();
+        Ok(client.make_ref(m.send_and_receive_handle(Message::ApplyAndRun(handle, arg_handle))?))
+    }
 }

--- a/vmm/src/client.rs
+++ b/vmm/src/client.rs
@@ -24,6 +24,13 @@ impl<'a> Client<'a> {
     }
 }
 
+impl Drop for Client<'_> {
+    fn drop(&mut self) {
+        let mut m = self.messenger.lock();
+        m.send(Message::Exit).unwrap();
+    }
+}
+
 pub struct Ref<'a, 'b, T: ArcaHandle>
 where
     'b: 'a,

--- a/vmm/src/client.rs
+++ b/vmm/src/client.rs
@@ -170,14 +170,11 @@ impl<'b> Client<'b> {
         let (slice, a) = Arc::into_raw_with_allocator(buf);
         let (ptr, len) = slice.to_raw_parts();
         let ptr = a.to_offset(ptr);
-        let mut m = self.messenger.lock();
-        if let ArcaRef::Blob(b) =
-            self.make_ref(m.send_and_receive_handle(Message::CreateBlob { ptr, len })?)
-        {
-            Ok(b)
-        } else {
-            Err(RingBufferError::TypeError)
-        }
+        let handle = BlobHandle { ptr, len };
+        Ok(BlobRef {
+            handle,
+            client: self,
+        })
     }
 
     pub fn create_tree<'a>(&'a self, tree: Vec<ArcaRef>) -> Result<TreeRef<'a, 'b>, RingBufferError>

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(allocator_api)]
 #![feature(ptr_metadata)]
+#![feature(maybe_uninit_write_slice)]
+#![feature(box_into_inner)]
 
 pub mod client;


### PR DESCRIPTION
These changes improve the performance of invoking an Arca from Linux
via the RingBuffer from O(10ms) to O(10µs).  Additionally, they
replace the custom serializer/deserializer with a Rust crate that does
the same thing more ergonomically (bincode).
