### PR TITLE
feat: add macros for nicer testing

### DIFF
--- a/arcade/Cargo.toml
+++ b/arcade/Cargo.toml
@@ -14,7 +14,7 @@ klog-warn = ["kernel/klog-warn"]
 klog-error = ["kernel/klog-error"]
 klog-off = ["kernel/klog-off"]
 debugcon = ["kernel/debugcon"]
-testing-mode = []
+testing-mode = ["kernel/testing-mode"]
 
 [dependencies]
 arca = { path = "../arca", features = ["serde"] }

--- a/arcade/build.rs
+++ b/arcade/build.rs
@@ -6,5 +6,7 @@ fn main() -> Result<()> {
     println!("cargo::rustc-link-arg=-T{dir}/etc/memmap.ld");
     println!("cargo::rustc-link-arg=-no-pie");
 
+    println!("cargo::rerun-if-changed={dir}/src/testing.rs");
+
     Ok(())
 }

--- a/arcade/src/main.rs
+++ b/arcade/src/main.rs
@@ -5,12 +5,10 @@
 #![feature(iterator_try_collect)]
 #![feature(box_patterns)]
 #![feature(never_type)]
+#![feature(proc_macro_hygiene)]
 #![allow(dead_code)]
 #![cfg_attr(feature = "testing-mode", allow(unreachable_code))]
 #![cfg_attr(feature = "testing-mode", allow(unused))]
-
-#[cfg(feature = "testing-mode")]
-mod testing;
 
 use core::time::Duration;
 
@@ -31,6 +29,15 @@ use crate::{
 };
 use vfs::mem::MemDir;
 
+#[arca_module_test]
+mod testing;
+
+#[arca_module_test]
+mod dummy_testing {
+    #[arca_test]
+    fn test_abc() {}
+}
+
 extern crate alloc;
 
 const SERVER: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_MEMCACHED"));
@@ -39,7 +46,8 @@ const SERVER: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_MEMCACHED"));
 async fn main(_: &[usize]) {
     #[cfg(feature = "testing-mode")]
     {
-        crate::testing::test_runner();
+        crate::testing::__MODULE_TESTS.run();
+        crate::dummy_testing::__MODULE_TESTS.run();
         return;
     }
 

--- a/arcade/src/testing.rs
+++ b/arcade/src/testing.rs
@@ -1,6 +1,7 @@
 use kernel::prelude::*;
 extern crate alloc;
 
+#[arca_test]
 fn test_serde_null() {
     let null = Value::Null(Null::new());
     let bytes_vec = postcard::to_allocvec(&null).unwrap();
@@ -8,6 +9,7 @@ fn test_serde_null() {
     assert_eq!(deserialized_null, null);
 }
 
+#[arca_test]
 fn test_serde_word() {
     let word = Value::Word(1.into());
     let bytes_vec = postcard::to_allocvec(&word).unwrap();
@@ -15,6 +17,7 @@ fn test_serde_word() {
     assert_eq!(deserialized_word, word);
 }
 
+#[arca_test]
 fn test_serde_blob() {
     let blob = Value::Blob("hello, world!".into());
     let bytes_vec = postcard::to_allocvec(&blob).unwrap();
@@ -22,6 +25,7 @@ fn test_serde_blob() {
     assert_eq!(deserialized_blob, blob);
 }
 
+#[arca_test]
 fn test_serde_tuple() {
     let tuple = Value::Tuple((1, 2, 3).into());
     let bytes_vec = postcard::to_allocvec(&tuple).unwrap();
@@ -29,6 +33,7 @@ fn test_serde_tuple() {
     assert_eq!(deserialized_tuple, tuple);
 }
 
+#[arca_test]
 fn test_serde_page() {
     let page = Value::Page(Page::new(1));
     let bytes_vec = postcard::to_allocvec(&page).unwrap();
@@ -36,6 +41,7 @@ fn test_serde_page() {
     assert_eq!(deserialized_page, page);
 }
 
+#[arca_test]
 fn test_serde_table() {
     let table = Value::Table(Table::new(1));
     let bytes_vec = postcard::to_allocvec(&table).unwrap();
@@ -43,6 +49,7 @@ fn test_serde_table() {
     assert_eq!(deserialized_table, table);
 }
 
+#[arca_test]
 fn test_serde_function() {
     let arca = Arca::new();
     let inner_func: arca::Function<Runtime> = Function::from(arca);
@@ -50,14 +57,4 @@ fn test_serde_function() {
     let bytes_vec = postcard::to_allocvec(&func).unwrap();
     let deserialized_func: Value = postcard::from_bytes(&bytes_vec).unwrap();
     assert_eq!(deserialized_func, func);
-}
-
-pub fn test_runner() {
-    test_serde_null();
-    test_serde_word();
-    test_serde_blob();
-    test_serde_tuple();
-    test_serde_page();
-    test_serde_table();
-    test_serde_function();
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,6 +16,7 @@ klog-warn = []
 klog-error = []
 klog-off = []
 debugcon = []
+testing-mode = ["macros/testing-mode"]
 
 [dependencies]
 bitfield-struct = "0.7.0"

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(bigint_helper_methods)]
 #![feature(box_as_ptr)]
 #![feature(box_into_inner)]
-#![feature(custom_test_frameworks)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array_transpose)]
@@ -13,8 +12,6 @@
 #![feature(ptr_metadata)]
 #![feature(slice_ptr_get)]
 #![feature(vec_into_raw_parts)]
-#![test_runner(crate::testing::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 extern crate alloc;
 
@@ -54,8 +51,8 @@ pub use lapic::LAPIC;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(test)]
-mod testing;
+#[cfg(feature = "testing-mode")]
+pub mod testing;
 
 #[no_mangle]
 static mut EXIT_CODE: u8 = 0;

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -24,6 +24,10 @@ pub use crate::{
     shutdown,
     types::{Arca, Blob, Entry, Function, Null, Page, Runtime, Table, Tuple, Value, Word},
 };
+
+#[cfg(feature = "testing-mode")]
+pub use crate::testing::{ModuleDesc, TestDescAndFn};
+
 pub use arca::DataType;
 pub use common::buddy::BuddyAllocator;
 pub use common::refcnt::RefCnt;
@@ -33,4 +37,4 @@ pub use common::util::oneshot;
 pub use common::util::rwlock::RwLock;
 pub use common::util::sorter;
 pub use common::util::spinlock::SpinLock;
-pub use macros::kmain;
+pub use macros::{arca_module_test, arca_test, inline_module_test, kmain};

--- a/kernel/src/testing.rs
+++ b/kernel/src/testing.rs
@@ -1,15 +1,31 @@
-pub fn test_runner(tests: &[&dyn Fn()]) {
-    log::info!("Running {} tests", tests.len());
-    for test in tests {
-        test();
+#![allow(dead_code)]
+
+pub struct TestDescAndFn {
+    pub name: &'static str,
+    pub function: fn() -> (),
+}
+
+impl TestDescAndFn {
+    fn run(&self) {
+        (self.function)();
+        log::info!("Test {} PASS", self.name);
     }
 }
 
-#[no_mangle]
-extern "C" fn kmain() -> ! {
-    if crate::cpuinfo::is_bootstrap() {
-        crate::test_main();
-        crate::shutdown()
+pub struct ModuleDesc {
+    pub name: &'static str,
+    pub functions: &'static [TestDescAndFn],
+}
+
+impl ModuleDesc {
+    pub fn run(&self) {
+        log::info!(
+            "Running {} tests for module {}",
+            self.functions.len(),
+            self.name
+        );
+        for f in self.functions {
+            f.run();
+        }
     }
-    crate::halt();
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,3 +11,7 @@ syn = "2.0.67"
 
 [lib]
 proc-macro = true
+
+[features]
+default = []
+testing-mode = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -20,6 +20,21 @@ pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn arca_module_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    testing::arca_module_test(attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn inline_module_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    testing::inline_module_test(attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn arca_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
 pub fn kmain(attr: TokenStream, item: TokenStream) -> TokenStream {
     util::kmain(attr, item)
 }

--- a/macros/src/testing.rs
+++ b/macros/src/testing.rs
@@ -4,6 +4,12 @@ use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Ident, ItemFn};
 
+#[cfg(feature = "testing-mode")]
+use {
+    quote::ToTokens,
+    syn::{Attribute, Item, ItemMod},
+};
+
 fn kernel_ident() -> Ident {
     let found_crate = crate_name("kernel").expect("kernel is present in `Cargo.toml`");
 
@@ -83,4 +89,114 @@ pub fn bench(_: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+#[cfg_attr(not(feature = "testing-mode"), allow(unused))]
+pub fn inline_module_test(_: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "testing-mode")]
+    {
+        let mut module = parse_macro_input!(item as ItemMod);
+
+        let Some((_, items)) = &mut module.content else {
+            panic!("inline_module_test: module must be inline (use `mod m {{ }} or `include!()`")
+        };
+
+        fn has_attr(attrs: &[Attribute], name: &str) -> bool {
+            attrs.iter().any(|a| a.path().is_ident(name))
+        }
+
+        fn generate_desc(item: &ItemFn, test_descs: &mut Vec<Item>, tests: &mut Vec<Ident>) {
+            if has_attr(&item.attrs, "arca_test") {
+                let test_name = item.sig.ident.clone();
+                let test_obj_name = format_ident!("{}_obj", item.sig.ident);
+                let test_desc = quote! {
+                    #[allow(non_upper_case_globals)]
+                    const #test_obj_name: TestDescAndFn = TestDescAndFn {
+                        name: stringify!(#test_name),
+                        function: #test_name
+                    };
+                };
+
+                test_descs
+                    .push(syn::parse::<Item>(test_desc.into()).expect("Failed to parse test"));
+                tests.push(test_obj_name);
+            }
+        }
+
+        let use_clause = quote! {
+            use crate::{TestDescAndFn, ModuleDesc, vec, arca_test};
+        };
+        let mut tests = vec![];
+        let mut test_descs = vec![];
+
+        for it in items.as_slice() {
+            if let Item::Fn(func) = it {
+                generate_desc(func, &mut test_descs, &mut tests)
+            }
+        }
+
+        let module_name = module.ident.clone();
+
+        let module_desc = quote! {
+            pub const __MODULE_TESTS: ModuleDesc = ModuleDesc {
+                name: stringify!(#module_name),
+                functions: &[ #( #tests ),* ]
+            };
+        };
+
+        items.push(syn::parse::<Item>(use_clause.into()).unwrap());
+        items.extend(test_descs);
+        items.push(syn::parse(module_desc.into()).unwrap());
+        module.into_token_stream().into()
+    }
+
+    #[cfg(not(feature = "testing-mode"))]
+    {
+        quote! {}.into()
+    }
+}
+
+#[cfg_attr(not(feature = "testing-mode"), allow(unused))]
+pub fn arca_module_test(_: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(feature = "testing-mode")]
+    {
+        let module = parse_macro_input!(item as ItemMod);
+        let module_name = module.ident.clone();
+
+        match &module.content {
+            Some(_) => {
+                let module_content = module.into_token_stream();
+                quote! {
+                    #[inline_module_test]
+                    #module_content
+                }
+                .into()
+            }
+            None => {
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
+
+                let mut src_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
+                src_dir.push("src");
+                src_dir.push(module_name.to_string() + ".rs");
+                let file_content: proc_macro2::TokenStream = fs::read_to_string(src_dir)
+                    .expect("arca_module_test: failed to load src file")
+                    .parse()
+                    .expect("arca_module_test: Failed to parse");
+                quote! {
+                    #[inline_module_test]
+                    mod #module_name {
+                        #file_content
+                    }
+                }
+                .into()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "testing-mode"))]
+    {
+        quote! {}.into()
+    }
 }


### PR DESCRIPTION
This PR adds macros that automatically generates logging for test cases and list of tests for modules.

Known issues:
* Testing files (ones similar to integration tests) need to be added to build.rs as `rerun-if-changed` manually
* Need to invoke `__MODULE_TESTS.run()` manually on each of the module that contains tests