### PR TITLE
fix: deserialize entry

### DIFF
--- a/arca/src/lib.rs
+++ b/arca/src/lib.rs
@@ -29,7 +29,7 @@ pub mod prelude {
         value::Value, value::ValueRef,
     };
     #[cfg(feature = "alloc")]
-    pub(crate) use alloc::{vec, vec::Vec};
+    pub(crate) use alloc::{format, vec, vec::Vec};
 }
 
 pub use prelude::*;

--- a/arca/src/serde.rs
+++ b/arca/src/serde.rs
@@ -179,8 +179,8 @@ impl<'de, R: Runtime> Visitor<'de> for ValueVisitor<R> {
                 let v = variant_access.newtype_variant::<Function<R>>()?;
                 Ok(Value::Function(v))
             }
-            _other => Err(serde::de::Error::unknown_variant(
-                "other",
+            other => Err(serde::de::Error::unknown_variant(
+                &format!("{}", other),
                 &["Null", "Word", "Blob", "Tuple", "Page", "Table"],
             )),
         }
@@ -389,8 +389,8 @@ impl<'de, R: Runtime> Visitor<'de> for EntryVisitor<R> {
                 let v = variant_access.newtype_variant::<Table<R>>()?;
                 Ok(Entry::RWTable(v))
             }
-            _other => Err(serde::de::Error::unknown_variant(
-                "other",
+            other => Err(serde::de::Error::unknown_variant(
+                &format!("{}", other),
                 &["Null", "ROPage", "RWPage", "ROTable", "RWTable"],
             )),
         }

--- a/arcade/src/testing.rs
+++ b/arcade/src/testing.rs
@@ -80,6 +80,24 @@ fn test_serde_rwtable() {
     assert_eq!(deserialized_rwtable, rwtable);
 }
 
+fn test_value_error() {
+    let unknown_variant = [7, 0];
+    let deserialized: Result<Value, postcard::Error> = postcard::from_bytes(&unknown_variant);
+    let deserialized_error = deserialized.expect_err("should have been err");
+    let error =
+        serde::de::Error::unknown_variant("7", &["Null", "Word", "Blob", "Tuple", "Page", "Table"]);
+    assert_eq!(deserialized_error, error);
+}
+
+fn test_entry_error() {
+    let unknown_variant = [5, 0];
+    let deserialized: Result<Entry, postcard::Error> = postcard::from_bytes(&unknown_variant);
+    let deserialized_error = deserialized.expect_err("should have been err");
+    let error =
+        serde::de::Error::unknown_variant("5", &["Null", "ROPage", "RWPage", "ROTable", "RWTable"]);
+    assert_eq!(deserialized_error, error);
+}
+
 pub fn test_runner() {
     test_serde_null();
     test_serde_word();
@@ -92,4 +110,6 @@ pub fn test_runner() {
     test_serde_rwpage();
     test_serde_rotable();
     test_serde_rwtable();
+    test_value_error();
+    test_entry_error();
 }


### PR DESCRIPTION
Entries can now be deserialized with tests in /arcade/src/testing.rs