### PR TITLE
fix: rename bigint_helper_methods to widening_mul

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 #![feature(allocator_api)]
-#![feature(bigint_helper_methods)]
+#![feature(widening_mul)]
 #![feature(box_as_ptr)]
 #![feature(box_into_inner)]
 #![feature(maybe_uninit_array_assume_init)]


### PR DESCRIPTION
  - Rename `bigint_helper_methods` feature gate to `widening_mul` in
   `kernel/src/lib.rs`
  - Fixes compilation on nightly-2026-02-03+

`bigint_helper_methods` was split into separate features in [rust-lang/rust#152018](https://github.com/rust-lang/rust/pull/152018) (merged 2026-02-03, Rust 1.95.0)
