### PR TITLE
fix: 1.95.0 nightly

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(slice_from_ptr_range)]
 #![feature(sync_unsafe_cell)]
 #![feature(try_trait_v2)]
-#![feature(atomic_try_update)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![cfg_attr(feature = "std", feature(thread_id_value))]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 #![feature(allocator_api)]
-#![feature(bigint_helper_methods)]
+#![feature(widening_mul)]
 #![feature(box_as_ptr)]
 #![feature(box_into_inner)]
 #![feature(maybe_uninit_array_assume_init)]


### PR DESCRIPTION
- Rename `bigint_helper_methods` feature gate to `widening_mul` in `kernel/src/lib.rs` [rust-lang/rust#152018](https://github.com/rust-lang/rust/pull/152018)
- Remove stabilized `atomic_try_update` feature gate from `common/src/lib.rs` [rust-lang/rust#148590](https://github.com/rust-lang/rust/pull/148590)