### PR TITLE
feat: bidirectional pipe

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod elfloader;
 pub mod ipaddr;
 pub mod sendable;
 pub mod util;
+pub mod pipe;
 
 #[cfg(feature = "std")]
 pub mod mmap;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod elfloader;
 pub mod ipaddr;
 pub mod pipe;
 pub mod sendable;
+pub mod sync_stream;
 pub mod util;
 
 #[cfg(feature = "std")]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,9 +17,9 @@ pub mod bitpack;
 pub mod controlreg;
 pub mod elfloader;
 pub mod ipaddr;
+pub mod pipe;
 pub mod sendable;
 pub mod util;
-pub mod pipe;
 
 #[cfg(feature = "std")]
 pub mod mmap;

--- a/common/src/pipe.rs
+++ b/common/src/pipe.rs
@@ -1,0 +1,27 @@
+//! # arca-pipe
+//!
+//! A `no_std`-compatible, lock-free bidirectional byte pipe built from two
+//! single-producer, single-consumer (SPSC) ring buffers over shared memory.
+//!
+//! This is the lowest-level transport primitive in arca-networking — both the
+//! control protocol and per-connection data streams are built on top of it.
+//!
+//! The pipe is a raw byte stream with no message framing. Higher layers
+//! (control protocol, data protocol) add their own framing on top.
+
+
+mod error;
+mod traits;
+mod ring;
+mod ring_producer;
+mod ring_consumer;
+mod shared_memory_region;
+mod bidirectional_pipe;
+
+pub use error::PipeError;
+pub use traits::{Read, Write};
+pub use ring::{RingData, RingHeader};
+pub use ring_producer::RingProducer;
+pub use ring_consumer::RingConsumer;
+pub use shared_memory_region::SharedMemoryRegion;
+pub use bidirectional_pipe::{BidirectionalPipe, Side};

--- a/common/src/pipe.rs
+++ b/common/src/pipe.rs
@@ -9,19 +9,18 @@
 //! The pipe is a raw byte stream with no message framing. Higher layers
 //! (control protocol, data protocol) add their own framing on top.
 
-
-mod error;
-mod traits;
-mod ring;
-mod ring_producer;
-mod ring_consumer;
-mod shared_memory_region;
 mod bidirectional_pipe;
+mod error;
+mod ring;
+mod ring_consumer;
+mod ring_producer;
+mod shared_memory_region;
+mod traits;
 
-pub use error::PipeError;
-pub use traits::{Read, Write};
-pub use ring::{RingData, RingHeader};
-pub use ring_producer::RingProducer;
-pub use ring_consumer::RingConsumer;
-pub use shared_memory_region::SharedMemoryRegion;
 pub use bidirectional_pipe::{BidirectionalPipe, Side};
+pub use error::PipeError;
+pub use ring::{RingData, RingHeader};
+pub use ring_consumer::RingConsumer;
+pub use ring_producer::RingProducer;
+pub use shared_memory_region::SharedMemoryRegion;
+pub use traits::{Read, Write};

--- a/common/src/pipe.rs
+++ b/common/src/pipe.rs
@@ -22,5 +22,5 @@ pub use error::PipeError;
 pub use ring::{RingData, RingHeader};
 pub use ring_consumer::RingConsumer;
 pub use ring_producer::RingProducer;
-pub use shared_memory_region::SharedMemoryRegion;
+pub use shared_memory_region::{RawSharedMemoryRegion, SharedMemoryRegion};
 pub use traits::{Read, Write};

--- a/common/src/pipe/Pipe.md
+++ b/common/src/pipe/Pipe.md
@@ -53,14 +53,14 @@ Both operations are **non-blocking**, return immediately if the ring
 is full or empty.
 
 **`RingProducer::write(buf)`**
-- Writes `min(buf.len(), free_space)` bytes into the ring.
+- Writes `min(buf.len(), writable_len)` bytes into the ring.
 - Returns the number of bytes actually written OR returns `WouldBlock` 
-  if the ring is full (`free_space == 0`).
+  if the ring is full (`writable_len == 0`).
 
 **`RingConsumer::read(buf)`**
-- Reads `min(buf.len(), used_space)` bytes from the ring.
+- Reads `min(buf.len(), readable_len)` bytes from the ring.
 - Returns the number of bytes actually read OR returns `WouldBlock` if the 
-  ring is empty (`used_space == 0`).
+  ring is empty (`readable_len == 0`).
 
 Callers that need blocking behavior loop on `WouldBlock` (see §3).
 

--- a/common/src/pipe/Pipe.md
+++ b/common/src/pipe/Pipe.md
@@ -1,0 +1,116 @@
+# Arca Data Pipe Protocol
+
+This doc specifies the **data pipe**: how bytes move between Arca and
+the Linux monitor for an established connection. The control protocol
+(`PROTOCOL.md`) handles session setup and hands off a `DataPipeInfo`
+(SHM handle + ring size); this doc covers everything after that handoff.
+
+---
+
+## 1. Overview
+
+Each connection gets its own **bidirectional pipe**, a pair of
+single-producer/single-consumer (SPSC) ring buffers in a shared-memory
+region. One ring carries bytes Arca→Linux (outgoing), the other Linux→Arca
+(incoming). The monitor relays bytes between the ring and the kernel
+`TcpStream`; Arca reads and writes through `SyncStream` / `AsyncStream`.
+
+```
+  Arca                shared memory               Monitor
+  ────                ─────────────               ───────
+  SyncStream ──write──► Ring A (A→B) ──read──► pipe_to_tcp → TcpStream
+  SyncStream ◄──read──  Ring B (B→A) ◄──write── tcp_to_pipe ← TcpStream
+```
+
+---
+
+## 2. Ring layer (`arca-pipe`)
+
+### 2.1 Ring buffer
+
+Each ring is a fixed-capacity byte buffer in shared memory with a header
+and a data region:
+
+```
+[RingHeader: 24 bytes][Data: ring_size bytes]
+```
+
+`RingHeader` (stored in shared memory, all fields atomic):
+
+```
+read_cursor:   AtomicU64   — monotonically increasing logical read position
+write_cursor:  AtomicU64   — monotonically increasing logical write position
+writer_closed: AtomicBool  — set by the producer when it will write no more
+reader_closed: AtomicBool  — set by the consumer when it will read no more
+```
+
+Physical position is `cursor % ring_size`. Cursors never reset; wrapping
+arithmetic handles overflow.
+
+### 2.2 Read and write
+
+Both operations are **non-blocking**, return immediately if the ring
+is full or empty.
+
+**`RingProducer::write(buf)`**
+- Writes `min(buf.len(), free_space)` bytes into the ring.
+- Returns the number of bytes actually written OR returns `WouldBlock` 
+  if the ring is full (`free_space == 0`).
+
+**`RingConsumer::read(buf)`**
+- Reads `min(buf.len(), used_space)` bytes from the ring.
+- Returns the number of bytes actually read OR returns `WouldBlock` if the 
+  ring is empty (`used_space == 0`).
+
+Callers that need blocking behavior loop on `WouldBlock` (see §3).
+
+### 2.3 Close flags
+
+Each ring has two close flags in its header, set independently by each end:
+
+| Flag            | Set by   | Meaning                                      |
+| --------------- | -------- | -------------------------------------------- |
+| `writer_closed` | Producer | No more bytes will be written to this ring.  |
+| `reader_closed` | Consumer | No more bytes will be read from this ring.   |
+
+A ring is **closed** when both flags are set. A `BidirectionalPipe` is
+**fully closed** when both of its rings are closed (all four flags set).
+
+### 2.4 `BidirectionalPipe` layout and API
+
+Total shared-memory size for one pipe:
+
+```
+required_size(ring_size) = 2 × (24 + ring_size)  bytes
+```
+
+Layout: `[HeaderA][DataA: ring_size][HeaderB][DataB: ring_size]`
+
+Side A's producer writes to Ring A; Side B's consumer reads from Ring A, 
+and vice versa for Ring B.
+
+**Close API on `BidirectionalPipe`:**
+
+| Method                   | What it does                                               |
+| ------------------------ | ---------------------------------------------------------- |
+| `close_write()`          | Sets `writer_closed` on the outgoing ring.                 |
+| `close_read()`           | Sets `reader_closed` on the incoming ring.                 |
+| `is_peer_write_closed()` | Reads `writer_closed` on the incoming ring (peer set it).  |
+| `is_peer_read_closed()`  | Reads `reader_closed` on the outgoing ring (peer set it).  |
+| `is_closed()`            | True when all four flags across both rings are set.        |
+
+---
+
+## 3. Where the code lives
+
+```
+arca/common/src/
+├── pipe/                   # ring buffers, BidirectionalPipe
+│   └── src/
+│       ├── Pipe.md
+│       ├── traits.rs       #   Read, Write traits; Write::write_all default
+│       ├── ring.rs         #   RingHeader (cursors + close flags), RingData
+│       ├── ring_producer.rs#   RingProducer — write, close_writer, is_reader_closed
+│       ├── ring_consumer.rs#   RingConsumer — read, close_reader, is_writer_closed
+│       └── bidirectional_pipe.rs  # BidirectionalPipe — close_write/read, is_closed
+```

--- a/common/src/pipe/Pipe.md
+++ b/common/src/pipe/Pipe.md
@@ -54,13 +54,15 @@ is full or empty.
 
 **`RingProducer::write(buf)`**
 - Writes `min(buf.len(), writable_len)` bytes into the ring.
-- Returns the number of bytes actually written OR returns `WouldBlock` 
-  if the ring is full (`writable_len == 0`).
+- Returns the number of bytes written, `Err(WouldBlock)` if the ring is full
+  (`writable_len == 0`), or `Err(Closed)` if the reader has closed its end
+  (broken pipe — the write can never be consumed).
 
 **`RingConsumer::read(buf)`**
 - Reads `min(buf.len(), readable_len)` bytes from the ring.
-- Returns the number of bytes actually read OR returns `WouldBlock` if the 
-  ring is empty (`readable_len == 0`).
+- Returns the number of bytes read; `Ok(0)` for end-of-stream once the ring is
+  drained **and** the writer has closed (matching `std::io::Read`); or
+  `Err(WouldBlock)` if the ring is momentarily empty but the writer is still open.
 
 Callers that need blocking behavior loop on `WouldBlock` (see §3).
 
@@ -89,6 +91,14 @@ Layout: `[HeaderA][DataA: ring_size][HeaderB][DataB: ring_size]`
 Side A's producer writes to Ring A; Side B's consumer reads from Ring A, 
 and vice versa for Ring B.
 
+**Ownership.** `BidirectionalPipe<R>` owns its shared region through the
+`SharedMemoryRegion` trait (`R`) rather than borrowing it, so it carries no
+lifetime. The Arca side uses `RawSharedMemoryRegion` (a `(ptr, len)` handle with
+a no-op `Drop`); the host side can supply an `mmap`/`Arc`-backed `R` that unmaps
+on last drop. `split(self) -> (RingConsumer<R>, RingProducer<R>)` consumes the
+pipe into two independently owned, `Send` ends (each holds its own region clone),
+suitable for moving to separate threads / async tasks.
+
 **Close API on `BidirectionalPipe`:**
 
 | Method                   | What it does                                               |
@@ -105,12 +115,14 @@ and vice versa for Ring B.
 
 ```
 arca/common/src/
-├── pipe/                   # ring buffers, BidirectionalPipe
-│   └── src/
-│       ├── Pipe.md
-│       ├── traits.rs       #   Read, Write traits; Write::write_all default
-│       ├── ring.rs         #   RingHeader (cursors + close flags), RingData
-│       ├── ring_producer.rs#   RingProducer — write, close_writer, is_reader_closed
-│       ├── ring_consumer.rs#   RingConsumer — read, close_reader, is_writer_closed
-│       └── bidirectional_pipe.rs  # BidirectionalPipe — close_write/read, is_closed
+├── pipe.rs                 # module root, re-exports
+└── pipe/                   # ring buffers, BidirectionalPipe
+    ├── Pipe.md
+    ├── traits.rs              # Read, Write traits; Write::write_all default
+    ├── error.rs              # PipeError { WouldBlock, Closed }
+    ├── shared_memory_region.rs # SharedMemoryRegion trait + RawSharedMemoryRegion
+    ├── ring.rs               # RingHeader (cursors, close flags, readable_len/writable_len, is_closed), RingData
+    ├── ring_producer.rs      # RingProducer<R> — write, readable_len, close_writer, is_reader_closed
+    ├── ring_consumer.rs      # RingConsumer<R> — read, close_reader, is_writer_closed
+    └── bidirectional_pipe.rs # BidirectionalPipe<R> — split, close_write/read, is_closed
 ```

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -112,7 +112,7 @@ impl<'a> traits::Write for BidirectionalPipe<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::{Read, Write};
+    use crate::pipe::traits::{Read, Write};
 
     #[repr(align(8))]
     struct Aligned<const N: usize>([u8; N]);

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -86,12 +86,12 @@ impl<R: SharedMemoryRegion> BidirectionalPipe<R> {
     }
 
     /// Close this side's outgoing (write) direction.
-    pub fn close_write(&self) {
+    pub fn close_write(&mut self) {
         self.writer.close_writer();
     }
 
     /// Close this side's incoming (read) direction.
-    pub fn close_read(&self) {
+    pub fn close_read(&mut self) {
         self.reader.close_reader();
     }
 

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -3,7 +3,7 @@ use crate::pipe::ring::{RingData, RingHeader};
 use crate::pipe::ring_consumer::RingConsumer;
 use crate::pipe::ring_producer::RingProducer;
 use crate::pipe::shared_memory_region::SharedMemoryRegion;
-use crate::pipe::traits;
+use crate::pipe::traits::{self, OwnedSplit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Side {
@@ -24,6 +24,16 @@ pub enum Side {
 /// Memory layout: `[HeaderA][Ring A->B data][HeaderB][Ring B->A data]`.
 pub struct BidirectionalPipe<R: SharedMemoryRegion> {
     writer: RingProducer<R>,
+    reader: RingConsumer<R>,
+}
+
+#[allow(unused)]
+pub struct BidirectionalPipeWriteEnd<R: SharedMemoryRegion> {
+    writer: RingProducer<R>,
+}
+
+#[allow(unused)]
+pub struct BidirectionalPipeReadEnd<R: SharedMemoryRegion> {
     reader: RingConsumer<R>,
 }
 
@@ -81,8 +91,15 @@ impl<R: SharedMemoryRegion> BidirectionalPipe<R> {
     /// Each end already owns its own clone of the region handle, so the two can
     /// be moved to separate threads / async tasks and each independently keeps
     /// the shared mapping alive.
-    pub fn split(self) -> (RingConsumer<R>, RingProducer<R>) {
-        (self.reader, self.writer)
+    pub fn split(self) -> (BidirectionalPipeReadEnd<R>, BidirectionalPipeWriteEnd<R>) {
+        (
+            BidirectionalPipeReadEnd {
+                reader: self.reader,
+            },
+            BidirectionalPipeWriteEnd {
+                writer: self.writer,
+            },
+        )
     }
 
     /// Close this side's outgoing (write) direction.
@@ -117,9 +134,32 @@ impl<R: SharedMemoryRegion> traits::Read for BidirectionalPipe<R> {
     }
 }
 
+impl<R: SharedMemoryRegion> traits::Read for BidirectionalPipeReadEnd<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
+        self.reader.read(buf)
+    }
+}
+
 impl<R: SharedMemoryRegion> traits::Write for BidirectionalPipe<R> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
         self.writer.write(buf)
+    }
+}
+
+impl<R: SharedMemoryRegion> traits::Write for BidirectionalPipeWriteEnd<R> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
+        self.writer.write(buf)
+    }
+}
+
+impl<R: SharedMemoryRegion + Send + 'static> OwnedSplit for BidirectionalPipe<R> {
+    fn split(
+        self,
+    ) -> (
+        impl traits::Read + Send + 'static,
+        impl traits::Write + Send + 'static,
+    ) {
+        self.split()
     }
 }
 

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -34,11 +34,15 @@ impl<'a> BidirectionalPipe<'a> {
     /// created per region.
     pub fn new(region: &'a SharedMemoryRegion, ring_size: u64, side: Side) -> Self {
         assert!(region.len() >= Self::required_size(ring_size));
-        assert!(ring_size % core::mem::align_of::<RingHeader>() as u64 == 0,
-            "ring_size must be a multiple of 8 for header alignment");
+        assert!(
+            ring_size.is_multiple_of(core::mem::align_of::<RingHeader>() as u64),
+            "ring_size must be a multiple of 8 for header alignment"
+        );
         let base = region.as_ptr();
-        assert!(base.align_offset(core::mem::align_of::<RingHeader>()) == 0,
-            "shared memory region must be 8-byte aligned");
+        assert!(
+            base.align_offset(core::mem::align_of::<RingHeader>()) == 0,
+            "shared memory region must be 8-byte aligned"
+        );
 
         // Layout: [HeaderA (16)] [DataA (ring_size)] [HeaderB (16)] [DataB (ring_size)]
         // Interleaved so each header is adjacent to its data (cache locality)
@@ -116,9 +120,8 @@ mod tests {
     macro_rules! pipe_pair {
         ($ring:expr, $mem:ident, $a:ident, $b:ident) => {
             let mut $mem = Aligned([0u8; BidirectionalPipe::required_size($ring as u64) as usize]);
-            let region = unsafe {
-                SharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64)
-            };
+            let region =
+                unsafe { SharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64) };
             let mut $a = BidirectionalPipe::new(&region, $ring, Side::A);
             let mut $b = BidirectionalPipe::new(&region, $ring, Side::B);
         };
@@ -199,5 +202,4 @@ mod tests {
         a.read(&mut out).unwrap();
         assert_eq!(&out, b"bbdd");
     }
-
 }

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -255,4 +255,25 @@ mod tests {
         a.read(&mut out).unwrap();
         assert_eq!(&out, b"bbdd");
     }
+
+    #[test]
+    fn read_sees_eof_after_peer_closes_write() {
+        pipe_pair!(16, mem, a, b);
+        a.write(b"bye").unwrap();
+        a.close_write();
+        let mut out = [0u8; 8];
+        // Buffered bytes drain first...
+        assert_eq!(b.read(&mut out).unwrap(), 3);
+        assert_eq!(&out[..3], b"bye");
+        // ...then EOF as Ok(0).
+        assert_eq!(b.read(&mut out).unwrap(), 0);
+    }
+
+    #[test]
+    fn write_errs_after_peer_closes_read() {
+        pipe_pair!(16, mem, a, b);
+        // B abandons the A->B direction; A's writes can never be consumed.
+        b.close_read();
+        assert!(matches!(a.write(b"x"), Err(PipeError::Closed)));
+    }
 }

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -13,26 +13,35 @@ pub enum Side {
 
 /// One endpoint of a bidirectional pipe.
 ///
+/// Owns a [`RingProducer`] and [`RingConsumer`], each of which holds its own
+/// clone of the [`SharedMemoryRegion`] handle — so the pipe carries no lifetime
+/// and is not tied to a borrowed region. [`split`](Self::split) hands those two
+/// ends back as fully owned, `Send` values.
+///
+/// The pipe (and the ends returned by [`split`](Self::split)) are `Send`
+/// whenever `R: Send`.
+///
 /// Memory layout: `[HeaderA][Ring A->B data][HeaderB][Ring B->A data]`.
-pub struct BidirectionalPipe<'a> {
-    writer: RingProducer<'a>,
-    reader: RingConsumer<'a>,
+pub struct BidirectionalPipe<R: SharedMemoryRegion> {
+    writer: RingProducer<R>,
+    reader: RingConsumer<R>,
 }
 
 const HEADER_SIZE: u64 = core::mem::size_of::<RingHeader>() as u64;
 
-impl<'a> BidirectionalPipe<'a> {
+impl<R: SharedMemoryRegion> BidirectionalPipe<R> {
     /// Total bytes of shared memory needed for a given `ring_size`.
     pub const fn required_size(ring_size: u64) -> u64 {
         2 * (HEADER_SIZE + ring_size)
     }
 
-    /// Create a pipe endpoint over a shared memory region.
+    /// Create a pipe endpoint that takes ownership of a shared memory region.
     ///
-    /// Caller must ensure the region is zero-initialized before the first side
-    /// is constructed, and that exactly one `Side::A` and one `Side::B` are
-    /// created per region.
-    pub fn new(region: &'a SharedMemoryRegion, ring_size: u64, side: Side) -> Self {
+    /// The region handle is cloned into each ring end so the reader and writer
+    /// each keep the mapping alive on their own. Caller must ensure the region
+    /// is zero-initialized before the first side is constructed, and that
+    /// exactly one `Side::A` and one `Side::B` are created per region.
+    pub fn new(region: R, ring_size: u64, side: Side) -> Self {
         assert!(region.len() >= Self::required_size(ring_size));
         assert!(
             ring_size.is_multiple_of(core::mem::align_of::<RingHeader>() as u64),
@@ -44,12 +53,12 @@ impl<'a> BidirectionalPipe<'a> {
             "shared memory region must be 8-byte aligned"
         );
 
-        // Layout: [HeaderA (16)] [DataA (ring_size)] [HeaderB (16)] [DataB (ring_size)]
+        // Layout: [HeaderA (24)] [DataA (ring_size)] [HeaderB (24)] [DataB (ring_size)]
         // Interleaved so each header is adjacent to its data (cache locality)
         // and headers are separated by ring_size (avoids false sharing).
-        let header_a = unsafe { &*(base as *const RingHeader) };
+        let header_a = base as *const RingHeader;
         let data_a = unsafe { base.add(HEADER_SIZE as usize) };
-        let header_b = unsafe { &*(data_a.add(ring_size as usize) as *const RingHeader) };
+        let header_b = unsafe { data_a.add(ring_size as usize) as *const RingHeader };
         let data_b = unsafe { data_a.add(ring_size as usize + HEADER_SIZE as usize) };
 
         let (writer_header, writer_data, reader_header, reader_data) = match side {
@@ -57,18 +66,23 @@ impl<'a> BidirectionalPipe<'a> {
             Side::B => (header_b, data_b, header_a, data_a),
         };
 
-        let writer = RingProducer::new(writer_header, unsafe {
+        let writer = RingProducer::new(region.clone(), writer_header, unsafe {
             RingData::new(writer_data, ring_size)
         });
-        let reader = RingConsumer::new(reader_header, unsafe {
+        let reader = RingConsumer::new(region, reader_header, unsafe {
             RingData::new(reader_data, ring_size)
         });
         Self { writer, reader }
     }
 
-    /// Split into independent read and write halves (like `TcpStream::split`).
-    pub fn split(&mut self) -> (&mut RingConsumer<'a>, &mut RingProducer<'a>) {
-        (&mut self.reader, &mut self.writer)
+    /// Consume the pipe and split it into independent, owned read and write
+    /// ends (like `TcpStream::into_split`).
+    ///
+    /// Each end already owns its own clone of the region handle, so the two can
+    /// be moved to separate threads / async tasks and each independently keeps
+    /// the shared mapping alive.
+    pub fn split(self) -> (RingConsumer<R>, RingProducer<R>) {
+        (self.reader, self.writer)
     }
 
     /// Close this side's outgoing (write) direction.
@@ -97,13 +111,13 @@ impl<'a> BidirectionalPipe<'a> {
     }
 }
 
-impl<'a> traits::Read for BidirectionalPipe<'a> {
+impl<R: SharedMemoryRegion> traits::Read for BidirectionalPipe<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
         self.reader.read(buf)
     }
 }
 
-impl<'a> traits::Write for BidirectionalPipe<'a> {
+impl<R: SharedMemoryRegion> traits::Write for BidirectionalPipe<R> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
         self.writer.write(buf)
     }
@@ -112,6 +126,7 @@ impl<'a> traits::Write for BidirectionalPipe<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipe::shared_memory_region::RawSharedMemoryRegion;
     use crate::pipe::traits::{Read, Write};
 
     #[repr(align(8))]
@@ -119,17 +134,55 @@ mod tests {
 
     macro_rules! pipe_pair {
         ($ring:expr, $mem:ident, $a:ident, $b:ident) => {
-            let mut $mem = Aligned([0u8; BidirectionalPipe::required_size($ring as u64) as usize]);
-            let region =
-                unsafe { SharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64) };
-            let mut $a = BidirectionalPipe::new(&region, $ring, Side::A);
-            let mut $b = BidirectionalPipe::new(&region, $ring, Side::B);
+            let mut $mem = Aligned(
+                [0u8; BidirectionalPipe::<RawSharedMemoryRegion>::required_size($ring as u64)
+                    as usize],
+            );
+            // A `RawSharedMemoryRegion` is a `Copy` handle, so each side gets its
+            // own owned clone pointing at the same backing bytes.
+            let region = unsafe {
+                RawSharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64)
+            };
+            // `mut` is needed by tests that read/write; split-only tests don't.
+            #[allow(unused_mut)]
+            let mut $a = BidirectionalPipe::new(region, $ring, Side::A);
+            #[allow(unused_mut)]
+            let mut $b = BidirectionalPipe::new(region, $ring, Side::B);
         };
     }
 
     #[test]
     fn required_size_matches_layout() {
-        assert_eq!(BidirectionalPipe::required_size(64), 2 * (24 + 64));
+        assert_eq!(
+            BidirectionalPipe::<RawSharedMemoryRegion>::required_size(64),
+            2 * (24 + 64)
+        );
+    }
+
+    #[test]
+    fn owned_split_round_trip() {
+        pipe_pair!(32, mem, a, b);
+        let (mut a_rx, mut a_tx) = a.split();
+        let (mut b_rx, mut b_tx) = b.split();
+
+        a_tx.write(b"hi").unwrap();
+        let mut out = [0u8; 2];
+        b_rx.read(&mut out).unwrap();
+        assert_eq!(&out, b"hi");
+
+        b_tx.write(b"yo").unwrap();
+        a_rx.read(&mut out).unwrap();
+        assert_eq!(&out, b"yo");
+    }
+
+    #[test]
+    fn split_halves_and_pipe_are_send() {
+        // The whole point of dropping the lifetime: owned, `Send` endpoints
+        // that can move to other threads / async tasks.
+        fn assert_send<T: Send>() {}
+        assert_send::<BidirectionalPipe<RawSharedMemoryRegion>>();
+        assert_send::<RingConsumer<RawSharedMemoryRegion>>();
+        assert_send::<RingProducer<RawSharedMemoryRegion>>();
     }
 
     #[test]

--- a/common/src/pipe/bidirectional_pipe.rs
+++ b/common/src/pipe/bidirectional_pipe.rs
@@ -1,0 +1,203 @@
+use crate::pipe::error::PipeError;
+use crate::pipe::ring::{RingData, RingHeader};
+use crate::pipe::ring_consumer::RingConsumer;
+use crate::pipe::ring_producer::RingProducer;
+use crate::pipe::shared_memory_region::SharedMemoryRegion;
+use crate::pipe::traits;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    A,
+    B,
+}
+
+/// One endpoint of a bidirectional pipe.
+///
+/// Memory layout: `[HeaderA][Ring A->B data][HeaderB][Ring B->A data]`.
+pub struct BidirectionalPipe<'a> {
+    writer: RingProducer<'a>,
+    reader: RingConsumer<'a>,
+}
+
+const HEADER_SIZE: u64 = core::mem::size_of::<RingHeader>() as u64;
+
+impl<'a> BidirectionalPipe<'a> {
+    /// Total bytes of shared memory needed for a given `ring_size`.
+    pub const fn required_size(ring_size: u64) -> u64 {
+        2 * (HEADER_SIZE + ring_size)
+    }
+
+    /// Create a pipe endpoint over a shared memory region.
+    ///
+    /// Caller must ensure the region is zero-initialized before the first side
+    /// is constructed, and that exactly one `Side::A` and one `Side::B` are
+    /// created per region.
+    pub fn new(region: &'a SharedMemoryRegion, ring_size: u64, side: Side) -> Self {
+        assert!(region.len() >= Self::required_size(ring_size));
+        assert!(ring_size % core::mem::align_of::<RingHeader>() as u64 == 0,
+            "ring_size must be a multiple of 8 for header alignment");
+        let base = region.as_ptr();
+        assert!(base.align_offset(core::mem::align_of::<RingHeader>()) == 0,
+            "shared memory region must be 8-byte aligned");
+
+        // Layout: [HeaderA (16)] [DataA (ring_size)] [HeaderB (16)] [DataB (ring_size)]
+        // Interleaved so each header is adjacent to its data (cache locality)
+        // and headers are separated by ring_size (avoids false sharing).
+        let header_a = unsafe { &*(base as *const RingHeader) };
+        let data_a = unsafe { base.add(HEADER_SIZE as usize) };
+        let header_b = unsafe { &*(data_a.add(ring_size as usize) as *const RingHeader) };
+        let data_b = unsafe { data_a.add(ring_size as usize + HEADER_SIZE as usize) };
+
+        let (writer_header, writer_data, reader_header, reader_data) = match side {
+            Side::A => (header_a, data_a, header_b, data_b),
+            Side::B => (header_b, data_b, header_a, data_a),
+        };
+
+        let writer = RingProducer::new(writer_header, unsafe {
+            RingData::new(writer_data, ring_size)
+        });
+        let reader = RingConsumer::new(reader_header, unsafe {
+            RingData::new(reader_data, ring_size)
+        });
+        Self { writer, reader }
+    }
+
+    /// Split into independent read and write halves (like `TcpStream::split`).
+    pub fn split(&mut self) -> (&mut RingConsumer<'a>, &mut RingProducer<'a>) {
+        (&mut self.reader, &mut self.writer)
+    }
+
+    /// Close this side's outgoing (write) direction.
+    pub fn close_write(&self) {
+        self.writer.close_writer();
+    }
+
+    /// Close this side's incoming (read) direction.
+    pub fn close_read(&self) {
+        self.reader.close_reader();
+    }
+
+    /// True if the peer has closed their write side (no more data incoming).
+    pub fn is_peer_write_closed(&self) -> bool {
+        self.reader.is_writer_closed()
+    }
+
+    /// True if the peer has closed their read side (they will not read more data we send).
+    pub fn is_peer_read_closed(&self) -> bool {
+        self.writer.is_reader_closed()
+    }
+
+    /// True when both unidirectional rings are fully closed (all four flags set).
+    pub fn is_closed(&self) -> bool {
+        self.writer.is_closed() && self.reader.is_closed()
+    }
+}
+
+impl<'a> traits::Read for BidirectionalPipe<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
+        self.reader.read(buf)
+    }
+}
+
+impl<'a> traits::Write for BidirectionalPipe<'a> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
+        self.writer.write(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::{Read, Write};
+
+    #[repr(align(8))]
+    struct Aligned<const N: usize>([u8; N]);
+
+    macro_rules! pipe_pair {
+        ($ring:expr, $mem:ident, $a:ident, $b:ident) => {
+            let mut $mem = Aligned([0u8; BidirectionalPipe::required_size($ring as u64) as usize]);
+            let region = unsafe {
+                SharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64)
+            };
+            let mut $a = BidirectionalPipe::new(&region, $ring, Side::A);
+            let mut $b = BidirectionalPipe::new(&region, $ring, Side::B);
+        };
+    }
+
+    #[test]
+    fn required_size_matches_layout() {
+        assert_eq!(BidirectionalPipe::required_size(64), 2 * (24 + 64));
+    }
+
+    #[test]
+    fn round_trip_a_to_b() {
+        pipe_pair!(64, mem, a, b);
+        assert_eq!(a.write(b"ping").unwrap(), 4);
+        let mut out = [0u8; 4];
+        assert_eq!(b.read(&mut out).unwrap(), 4);
+        assert_eq!(&out, b"ping");
+    }
+
+    #[test]
+    fn round_trip_b_to_a() {
+        pipe_pair!(32, mem, a, b);
+        assert_eq!(b.write(b"pong!!").unwrap(), 6);
+        let mut out = [0u8; 6];
+        assert_eq!(a.read(&mut out).unwrap(), 6);
+        assert_eq!(&out, b"pong!!");
+    }
+
+    #[test]
+    fn both_directions_independent() {
+        pipe_pair!(32, mem, a, b);
+        a.write(b"hello").unwrap();
+        b.write(b"world").unwrap();
+
+        let mut from_a = [0u8; 5];
+        let mut from_b = [0u8; 5];
+        b.read(&mut from_a).unwrap();
+        a.read(&mut from_b).unwrap();
+        assert_eq!(&from_a, b"hello");
+        assert_eq!(&from_b, b"world");
+    }
+
+    #[test]
+    fn multi_lap() {
+        pipe_pair!(8, mem, a, b);
+        for i in 0u8..20 {
+            assert_eq!(a.write(&[i]).unwrap(), 1);
+            let mut out = [0u8; 1];
+            assert_eq!(b.read(&mut out).unwrap(), 1);
+            assert_eq!(out[0], i);
+        }
+    }
+
+    #[test]
+    fn fill_drain_refill() {
+        pipe_pair!(8, mem, a, b);
+        assert_eq!(a.write(b"12345678").unwrap(), 8);
+        let mut out = [0u8; 8];
+        assert_eq!(b.read(&mut out).unwrap(), 8);
+        assert_eq!(&out, b"12345678");
+
+        assert_eq!(a.write(b"abcdefgh").unwrap(), 8);
+        assert_eq!(b.read(&mut out).unwrap(), 8);
+        assert_eq!(&out, b"abcdefgh");
+    }
+
+    #[test]
+    fn interleaved_both_directions() {
+        pipe_pair!(16, mem, a, b);
+        a.write(b"aa").unwrap();
+        b.write(b"bb").unwrap();
+        a.write(b"cc").unwrap();
+        b.write(b"dd").unwrap();
+
+        let mut out = [0u8; 4];
+        b.read(&mut out).unwrap();
+        assert_eq!(&out, b"aacc");
+        a.read(&mut out).unwrap();
+        assert_eq!(&out, b"bbdd");
+    }
+
+}

--- a/common/src/pipe/error.rs
+++ b/common/src/pipe/error.rs
@@ -1,0 +1,16 @@
+use core::fmt;
+
+/// Errors returned by pipe operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeError {
+    /// Ring buffer is empty (read) or full (write). Try again later.
+    WouldBlock,
+}
+
+impl fmt::Display for PipeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PipeError::WouldBlock => write!(f, "operation would block"),
+        }
+    }
+}

--- a/common/src/pipe/error.rs
+++ b/common/src/pipe/error.rs
@@ -5,12 +5,18 @@ use core::fmt;
 pub enum PipeError {
     /// Ring buffer is empty (read) or full (write). Try again later.
     WouldBlock,
+    /// The other end has closed: writing to a pipe whose reader has closed.
+    ///
+    /// Note that read-side end-of-stream is *not* an error — a drained ring
+    /// whose writer has closed returns `Ok(0)` (EOF), matching `std::io::Read`.
+    Closed,
 }
 
 impl fmt::Display for PipeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PipeError::WouldBlock => write!(f, "operation would block"),
+            PipeError::Closed => write!(f, "pipe closed by peer"),
         }
     }
 }

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -39,6 +39,10 @@ impl RingHeader {
 ///
 /// Owns `(ptr, size)` together so call sites don't juggle them.
 /// Wrap-around is handled inside `write_at` / `read_at`.
+///
+/// Holds a raw `*mut u8`, so it is `!Send` by default. `Send` for the enclosing
+/// ring ends (`RingProducer`/`RingConsumer`) is provided by a manual
+/// `unsafe impl` there, justified by SPSC discipline — not by auto-derivation.
 pub struct RingData {
     ptr: *mut u8,
     size: u64,

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -15,7 +15,7 @@ pub struct RingHeader {
 
 impl RingHeader {
     /// Bytes available to read. Called by the consumer.
-    pub fn used_space(&self) -> u64 {
+    pub fn readable_len(&self) -> u64 {
         let write = self.write_cursor.load(Ordering::Acquire);
         let read = self.read_cursor.load(Ordering::Relaxed);
 
@@ -26,11 +26,11 @@ impl RingHeader {
     }
 
     /// Bytes available to write. Called by the producer.
-    pub fn free_space(&self, capacity: u64) -> u64 {
+    pub fn writable_len(&self, capacity: u64) -> u64 {
         let write = self.write_cursor.load(Ordering::Relaxed);
         let read = self.read_cursor.load(Ordering::Acquire);
 
-        // See used_space — wrapping_sub handles cursor overflow correctly
+        // See readable_len — wrapping_sub handles cursor overflow correctly
         capacity - write.wrapping_sub(read)
     }
 }
@@ -113,22 +113,22 @@ mod tests {
     #[test]
     fn empty_ring() {
         let h = header_with(0, 0);
-        assert_eq!(h.used_space(), 0);
-        assert_eq!(h.free_space(64), 64);
+        assert_eq!(h.readable_len(), 0);
+        assert_eq!(h.writable_len(64), 64);
     }
 
     #[test]
     fn partial_fill() {
         let h = header_with(10, 40);
-        assert_eq!(h.used_space(), 30);
-        assert_eq!(h.free_space(64), 34);
+        assert_eq!(h.readable_len(), 30);
+        assert_eq!(h.writable_len(64), 34);
     }
 
     #[test]
     fn full_ring() {
         let h = header_with(100, 164);
-        assert_eq!(h.used_space(), 64);
-        assert_eq!(h.free_space(64), 0);
+        assert_eq!(h.readable_len(), 64);
+        assert_eq!(h.writable_len(64), 0);
     }
 
     #[test]

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -5,6 +5,21 @@ use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 /// Cursors are monotonically increasing logical offsets. Physical positions
 /// are `cursor % ring_size`. The close flags signal orderly shutdown: the
 /// producer sets `writer_closed`; the consumer sets `reader_closed`.
+///
+/// # Memory ordering
+/// This is single-producer/single-consumer, and crucially each cursor has
+/// exactly one writer: the **producer** is the only side that mutates
+/// `write_cursor`, the **consumer** the only side that mutates `read_cursor`.
+/// All the `Ordering` choices below follow from that:
+/// - A side loads its **own** cursor with `Relaxed` — it is the sole writer, so
+///   no cross-thread synchronization is needed to read back its own value.
+/// - A side loads the **peer's** cursor with `Acquire`, which synchronizes-with
+///   the peer's `Release` store of that cursor. That release/acquire edge is
+///   what makes the bytes the cursor guards visible: the producer writes data
+///   then `Release`-stores `write_cursor`; the consumer `Acquire`-loads
+///   `write_cursor` then reads those bytes (and symmetrically for free space).
+/// - The same applies to the close flags: the setter uses `Release`, the peer's
+///   observer uses `Acquire`.
 #[repr(C)]
 pub struct RingHeader {
     pub read_cursor: AtomicU64,
@@ -14,7 +29,9 @@ pub struct RingHeader {
 }
 
 impl RingHeader {
-    /// Bytes available to read. Called by the consumer.
+    /// Bytes available to read. Called by the consumer (sole writer of
+    /// `read_cursor`), so its own cursor is `Relaxed` and the producer's
+    /// `write_cursor` is `Acquire`.
     pub fn readable_len(&self) -> u64 {
         let write = self.write_cursor.load(Ordering::Acquire);
         let read = self.read_cursor.load(Ordering::Relaxed);
@@ -25,7 +42,9 @@ impl RingHeader {
         write.wrapping_sub(read)
     }
 
-    /// Bytes available to write. Called by the producer.
+    /// Bytes available to write. Called by the producer (sole writer of
+    /// `write_cursor`), so its own cursor is `Relaxed` and the consumer's
+    /// `read_cursor` is `Acquire`.
     pub fn writable_len(&self, capacity: u64) -> u64 {
         let write = self.write_cursor.load(Ordering::Relaxed);
         let read = self.read_cursor.load(Ordering::Acquire);

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -1,0 +1,157 @@
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// Header for a single SPSC ring buffer, stored in shared memory.
+///
+/// Cursors are monotonically increasing logical offsets. Physical positions
+/// are `cursor % ring_size`. The close flags signal orderly shutdown: the
+/// producer sets `writer_closed`; the consumer sets `reader_closed`.
+#[repr(C)]
+pub struct RingHeader {
+    pub read_cursor: AtomicU64,
+    pub write_cursor: AtomicU64,
+    pub writer_closed: AtomicBool,
+    pub reader_closed: AtomicBool,
+}
+
+impl RingHeader {
+    /// Bytes available to read. Called by the consumer.
+    pub fn used_space(&self) -> u64 {
+        let write = self.write_cursor.load(Ordering::Acquire);
+        let read = self.read_cursor.load(Ordering::Relaxed);
+
+        // Cursors are monotonically increasing and never reset, but they can
+        // overflow u64. wrapping_sub gives the correct delta regardless, 
+        // also avoids panic on debug-mode subtraction overflow
+        write.wrapping_sub(read)
+    }
+
+    /// Bytes available to write. Called by the producer.
+    pub fn free_space(&self, capacity: u64) -> u64 {
+        let write = self.write_cursor.load(Ordering::Relaxed);
+        let read = self.read_cursor.load(Ordering::Acquire);
+
+        // See used_space — wrapping_sub handles cursor overflow correctly
+        capacity - write.wrapping_sub(read)
+    }
+}
+
+/// Raw data region of a single SPSC ring buffer.
+///
+/// Owns `(ptr, size)` together so call sites don't juggle them.
+/// Wrap-around is handled inside `write_at` / `read_at`.
+pub struct RingData {
+    ptr: *mut u8,
+    size: u64,
+}
+
+impl RingData {
+    /// # Safety
+    /// - `ptr` must point to a valid region of `size` bytes.
+    /// - Caller must guarantee SPSC discipline on top of this region.
+    pub unsafe fn new(ptr: *mut u8, size: u64) -> Self {
+        Self { ptr, size }
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Write `buf` starting at physical offset `cursor % size`, wrapping if needed.
+    /// Caller must ensure `buf.len() <= free space`.
+    pub fn write_at(&mut self, cursor: u64, buf: &[u8]) {
+        let size = self.size as usize;
+        let offset = (cursor % self.size) as usize;
+        let first = core::cmp::min(buf.len(), size - offset);
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr(), self.ptr.add(offset), first);
+            if buf.len() > first {
+                core::ptr::copy_nonoverlapping(
+                    buf.as_ptr().add(first),
+                    self.ptr,
+                    buf.len() - first,
+                );
+            }
+        }
+    }
+
+    /// Read into `buf` starting at physical offset `cursor % size`, wrapping if needed.
+    /// Caller must ensure `buf.len() <= used space`.
+    pub fn read_at(&self, cursor: u64, buf: &mut [u8]) {
+        let size = self.size as usize;
+        let offset = (cursor % self.size) as usize;
+        let first = core::cmp::min(buf.len(), size - offset);
+        unsafe {
+            core::ptr::copy_nonoverlapping(self.ptr.add(offset), buf.as_mut_ptr(), first);
+            if buf.len() > first {
+                core::ptr::copy_nonoverlapping(
+                    self.ptr,
+                    buf.as_mut_ptr().add(first),
+                    buf.len() - first,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_with(read: u64, write: u64) -> RingHeader {
+        RingHeader {
+            read_cursor: AtomicU64::new(read),
+            write_cursor: AtomicU64::new(write),
+            writer_closed: AtomicBool::new(false),
+            reader_closed: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn empty_ring() {
+        let h = header_with(0, 0);
+        assert_eq!(h.used_space(), 0);
+        assert_eq!(h.free_space(64), 64);
+    }
+
+    #[test]
+    fn partial_fill() {
+        let h = header_with(10, 40);
+        assert_eq!(h.used_space(), 30);
+        assert_eq!(h.free_space(64), 34);
+    }
+
+    #[test]
+    fn full_ring() {
+        let h = header_with(100, 164);
+        assert_eq!(h.used_space(), 64);
+        assert_eq!(h.free_space(64), 0);
+    }
+
+    #[test]
+    fn data_write_then_read_no_wrap() {
+        let mut mem = [0u8; 8];
+        let mut rd = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        rd.write_at(0, b"abcd");
+        let mut out = [0u8; 4];
+        rd.read_at(0, &mut out);
+        assert_eq!(&out, b"abcd");
+    }
+
+    #[test]
+    fn data_write_wraps() {
+        let mut mem = [0u8; 8];
+        let mut rd = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        rd.write_at(6, b"XYZW");
+        assert_eq!(&mem[6..8], b"XY");
+        assert_eq!(&mem[..2], b"ZW");
+    }
+
+    #[test]
+    fn data_read_wraps() {
+        let mut mem = *b"cdEFabXY";
+        let rd = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut out = [0u8; 6];
+        rd.read_at(6, &mut out);
+        assert_eq!(&out, b"XYcdEF");
+    }
+}

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -20,7 +20,7 @@ impl RingHeader {
         let read = self.read_cursor.load(Ordering::Relaxed);
 
         // Cursors are monotonically increasing and never reset, but they can
-        // overflow u64. wrapping_sub gives the correct delta regardless, 
+        // overflow u64. wrapping_sub gives the correct delta regardless,
         // also avoids panic on debug-mode subtraction overflow
         write.wrapping_sub(read)
     }

--- a/common/src/pipe/ring.rs
+++ b/common/src/pipe/ring.rs
@@ -52,6 +52,11 @@ impl RingHeader {
         // See readable_len — wrapping_sub handles cursor overflow correctly
         capacity - write.wrapping_sub(read)
     }
+
+    /// True when both ends of this ring are closed (orderly full shutdown).
+    pub fn is_closed(&self) -> bool {
+        self.writer_closed.load(Ordering::Acquire) && self.reader_closed.load(Ordering::Acquire)
+    }
 }
 
 /// Raw data region of a single SPSC ring buffer.

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -63,8 +63,7 @@ impl<R: SharedMemoryRegion> RingConsumer<R> {
 
     /// True when both ends of this ring are closed.
     pub fn is_closed(&self) -> bool {
-        self.header().writer_closed.load(Ordering::Acquire)
-            && self.header().reader_closed.load(Ordering::Acquire)
+        self.header().is_closed()
     }
 }
 

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -1,0 +1,135 @@
+use crate::pipe::error::PipeError;
+use crate::pipe::ring::{RingData, RingHeader};
+use crate::pipe::traits;
+use core::sync::atomic::Ordering;
+
+/// Consumer (read) end of a single SPSC ring buffer.
+pub struct RingConsumer<'a> {
+    header: &'a RingHeader,
+    data: RingData,
+}
+
+impl<'a> RingConsumer<'a> {
+    pub fn new(header: &'a RingHeader, data: RingData) -> Self {
+        Self { header, data }
+    }
+
+    /// Signal that this consumer will read no more bytes.
+    pub fn close_reader(&self) {
+        self.header.reader_closed.store(true, Ordering::Release);
+    }
+
+    /// True if the producer has closed its write end.
+    pub fn is_writer_closed(&self) -> bool {
+        self.header.writer_closed.load(Ordering::Acquire)
+    }
+
+    /// True when both ends of this ring are closed.
+    pub fn is_closed(&self) -> bool {
+        self.header.writer_closed.load(Ordering::Acquire)
+            && self.header.reader_closed.load(Ordering::Acquire)
+    }
+}
+
+impl<'a> traits::Read for RingConsumer<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
+        if buf.is_empty() { return Ok(0); }
+        let used = self.header.used_space();
+        if used == 0 {
+            return Err(PipeError::WouldBlock);
+        }
+
+        let n = core::cmp::min(buf.len() as u64, used) as usize;
+        let cursor = self.header.read_cursor.load(Ordering::Relaxed);
+        self.data.read_at(cursor, &mut buf[..n]);
+
+        // No standalone fence needed, release on the store guarantees the
+        // preceding read_at is visible before the cursor update
+        self.header.read_cursor.store(cursor + n as u64, Ordering::Release);
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipe::traits::Read;
+    use core::sync::atomic::AtomicU64;
+
+    fn header(read: u64, write: u64) -> RingHeader {
+        use core::sync::atomic::AtomicBool;
+        RingHeader {
+            read_cursor: AtomicU64::new(read),
+            write_cursor: AtomicU64::new(write),
+            writer_closed: AtomicBool::new(false),
+            reader_closed: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn simple_read() {
+        let mut mem = *b"hello...";
+        let h = header(0, 5);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 8];
+        assert_eq!(c.read(&mut out).unwrap(), 5);
+        assert_eq!(&out[..5], b"hello");
+        assert_eq!(h.read_cursor.load(Ordering::Relaxed), 5);
+    }
+
+    #[test]
+    fn partial_read() {
+        let mut mem = *b"abcdefgh";
+        let h = header(0, 8);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 3];
+        assert_eq!(c.read(&mut out).unwrap(), 3);
+        assert_eq!(&out, b"abc");
+    }
+
+    #[test]
+    fn wrap_around() {
+        let mut mem = *b"WXYZabcd";
+        let h = header(5, 12);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 8];
+        assert_eq!(c.read(&mut out).unwrap(), 7);
+        assert_eq!(&out[..7], b"bcdWXYZ");
+    }
+
+    #[test]
+    fn empty_ring_blocks() {
+        let mut mem = [0u8; 4];
+        let h = header(4, 4);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 4];
+        assert!(matches!(c.read(&mut out), Err(PipeError::WouldBlock)));
+    }
+
+    #[test]
+    fn zero_length_read_non_empty() {
+        let mut mem = *b"data";
+        let h = header(0, 4);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 0];
+        assert_eq!(c.read(&mut out).unwrap(), 0);
+        assert_eq!(h.read_cursor.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn zero_length_read_empty() {
+        let mut mem = [0u8; 4];
+        let h = header(0, 0);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut c = RingConsumer::new(&h, data);
+        let mut out = [0u8; 0];
+        assert_eq!(c.read(&mut out).unwrap(), 0);
+    }
+
+
+}

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -70,9 +70,20 @@ impl<R: SharedMemoryRegion> traits::Read for RingConsumer<R> {
         if buf.is_empty() {
             return Ok(0);
         }
+        // Observe `writer_closed` BEFORE the cursors. If the writer has closed,
+        // its final `write_cursor` store happened-before the close store
+        // (Acquire here synchronizes-with that Release), so the `used_space`
+        // load below is guaranteed to see every byte written. This prevents
+        // reporting EOF while unread bytes are still in flight.
+        let writer_closed = self.header().writer_closed.load(Ordering::Acquire);
         let used = self.header().used_space();
         if used == 0 {
-            return Err(PipeError::WouldBlock);
+            // Empty: EOF once the writer is done, otherwise nothing yet.
+            return if writer_closed {
+                Ok(0)
+            } else {
+                Err(PipeError::WouldBlock)
+            };
         }
 
         let n = core::cmp::min(buf.len() as u64, used) as usize;
@@ -153,6 +164,33 @@ mod tests {
         let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 4];
         assert!(matches!(c.read(&mut out), Err(PipeError::WouldBlock)));
+    }
+
+    #[test]
+    fn eof_when_writer_closed_and_empty() {
+        let mut mem = [0u8; 4];
+        let h = header(0, 0);
+        h.writer_closed.store(true, Ordering::Release);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
+        let mut out = [0u8; 4];
+        // Drained + writer closed = EOF, reported as Ok(0) (not WouldBlock).
+        assert_eq!(c.read(&mut out).unwrap(), 0);
+    }
+
+    #[test]
+    fn drains_remaining_then_eof() {
+        let mut mem = *b"hi..";
+        let h = header(0, 2);
+        h.writer_closed.store(true, Ordering::Release);
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
+        let mut out = [0u8; 4];
+        // Pending bytes are still delivered even though the writer has closed...
+        assert_eq!(c.read(&mut out).unwrap(), 2);
+        assert_eq!(&out[..2], b"hi");
+        // ...and only then is EOF reported.
+        assert_eq!(c.read(&mut out).unwrap(), 0);
     }
 
     #[test]

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -49,7 +49,10 @@ impl<R: SharedMemoryRegion> RingConsumer<R> {
     }
 
     /// Signal that this consumer will read no more bytes.
-    pub fn close_reader(&self) {
+    ///
+    /// Takes `&mut self`: there is exactly one consumer, so closing is an
+    /// exclusive operation and cannot race with a concurrent read on this end.
+    pub fn close_reader(&mut self) {
         self.header().reader_closed.store(true, Ordering::Release);
     }
 
@@ -72,11 +75,11 @@ impl<R: SharedMemoryRegion> traits::Read for RingConsumer<R> {
         }
         // Observe `writer_closed` BEFORE the cursors. If the writer has closed,
         // its final `write_cursor` store happened-before the close store
-        // (Acquire here synchronizes-with that Release), so the `used_space`
+        // (Acquire here synchronizes-with that Release), so the `readable_len`
         // load below is guaranteed to see every byte written. This prevents
         // reporting EOF while unread bytes are still in flight.
         let writer_closed = self.header().writer_closed.load(Ordering::Acquire);
-        let used = self.header().used_space();
+        let used = self.header().readable_len();
         if used == 0 {
             // Empty: EOF once the writer is done, otherwise nothing yet.
             return if writer_closed {

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -33,7 +33,9 @@ impl<'a> RingConsumer<'a> {
 
 impl<'a> traits::Read for RingConsumer<'a> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
-        if buf.is_empty() { return Ok(0); }
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let used = self.header.used_space();
         if used == 0 {
             return Err(PipeError::WouldBlock);
@@ -45,7 +47,9 @@ impl<'a> traits::Read for RingConsumer<'a> {
 
         // No standalone fence needed, release on the store guarantees the
         // preceding read_at is visible before the cursor update
-        self.header.read_cursor.store(cursor + n as u64, Ordering::Release);
+        self.header
+            .read_cursor
+            .store(cursor + n as u64, Ordering::Release);
         Ok(n)
     }
 }
@@ -130,6 +134,4 @@ mod tests {
         let mut out = [0u8; 0];
         assert_eq!(c.read(&mut out).unwrap(), 0);
     }
-
-
 }

--- a/common/src/pipe/ring_consumer.rs
+++ b/common/src/pipe/ring_consumer.rs
@@ -1,53 +1,87 @@
 use crate::pipe::error::PipeError;
 use crate::pipe::ring::{RingData, RingHeader};
+use crate::pipe::shared_memory_region::SharedMemoryRegion;
 use crate::pipe::traits;
 use core::sync::atomic::Ordering;
 
 /// Consumer (read) end of a single SPSC ring buffer.
-pub struct RingConsumer<'a> {
-    header: &'a RingHeader,
+///
+/// Like [`RingProducer`](crate::pipe::ring_producer::RingProducer), it owns its
+/// own clone of the [`SharedMemoryRegion`] handle and holds a raw header pointer
+/// rather than a borrow — so it carries no lifetime, keeps the mapping alive
+/// independently, and is a self-contained `Send` value returned by
+/// [`BidirectionalPipe::split`](crate::pipe::bidirectional_pipe::BidirectionalPipe::split).
+///
+/// [`SharedMemoryRegion`]: crate::pipe::shared_memory_region::SharedMemoryRegion
+pub struct RingConsumer<R: SharedMemoryRegion> {
+    /// Liveness only: keeps the mapped bytes alive for as long as this end exists.
+    ///
+    /// Drop order is safe regardless of field position: `header`/`data` are raw
+    /// pointers with no-op drops that never dereference the region, so dropping
+    /// `region` (which may unmap the memory for an mmap-backed `R`) cannot cause
+    /// a use-after-free.
+    #[allow(dead_code)]
+    region: R,
+    header: *const RingHeader,
     data: RingData,
 }
 
-impl<'a> RingConsumer<'a> {
-    pub fn new(header: &'a RingHeader, data: RingData) -> Self {
-        Self { header, data }
+// SAFETY: the consumer owns the sole read cursor of an SPSC ring. The raw
+// pointers address shared memory kept alive by the owned region handle; SPSC
+// discipline guarantees a single consumer, so moving it to another thread
+// (when `R: Send`) cannot introduce a data race.
+unsafe impl<R: SharedMemoryRegion + Send> Send for RingConsumer<R> {}
+
+impl<R: SharedMemoryRegion> RingConsumer<R> {
+    pub fn new(region: R, header: *const RingHeader, data: RingData) -> Self {
+        Self {
+            region,
+            header,
+            data,
+        }
+    }
+
+    /// Access the ring header living in shared memory.
+    fn header(&self) -> &RingHeader {
+        // SAFETY: pointer derived from a valid, aligned shared region; valid
+        // for the consumer's lifetime.
+        unsafe { &*self.header }
     }
 
     /// Signal that this consumer will read no more bytes.
     pub fn close_reader(&self) {
-        self.header.reader_closed.store(true, Ordering::Release);
+        self.header().reader_closed.store(true, Ordering::Release);
     }
 
     /// True if the producer has closed its write end.
     pub fn is_writer_closed(&self) -> bool {
-        self.header.writer_closed.load(Ordering::Acquire)
+        self.header().writer_closed.load(Ordering::Acquire)
     }
 
     /// True when both ends of this ring are closed.
     pub fn is_closed(&self) -> bool {
-        self.header.writer_closed.load(Ordering::Acquire)
-            && self.header.reader_closed.load(Ordering::Acquire)
+        self.header().writer_closed.load(Ordering::Acquire)
+            && self.header().reader_closed.load(Ordering::Acquire)
     }
 }
 
-impl<'a> traits::Read for RingConsumer<'a> {
+impl<R: SharedMemoryRegion> traits::Read for RingConsumer<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
         if buf.is_empty() {
             return Ok(0);
         }
-        let used = self.header.used_space();
+        let used = self.header().used_space();
         if used == 0 {
             return Err(PipeError::WouldBlock);
         }
 
         let n = core::cmp::min(buf.len() as u64, used) as usize;
-        let cursor = self.header.read_cursor.load(Ordering::Relaxed);
+        let cursor = self.header().read_cursor.load(Ordering::Relaxed);
         self.data.read_at(cursor, &mut buf[..n]);
 
         // No standalone fence needed, release on the store guarantees the
         // preceding read_at is visible before the cursor update
-        self.header
+        self.header()
             .read_cursor
             .store(cursor + n as u64, Ordering::Release);
         Ok(n)
@@ -57,8 +91,15 @@ impl<'a> traits::Read for RingConsumer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipe::shared_memory_region::RawSharedMemoryRegion;
     use crate::pipe::traits::Read;
     use core::sync::atomic::AtomicU64;
+
+    /// Region handle for tests — ownership/liveness only; the ring's actual
+    /// header/data pointers are supplied separately below.
+    fn raw(mem: &mut [u8]) -> RawSharedMemoryRegion {
+        unsafe { RawSharedMemoryRegion::from_raw(mem.as_mut_ptr(), mem.len() as u64) }
+    }
 
     fn header(read: u64, write: u64) -> RingHeader {
         use core::sync::atomic::AtomicBool;
@@ -75,7 +116,7 @@ mod tests {
         let mut mem = *b"hello...";
         let h = header(0, 5);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 8];
         assert_eq!(c.read(&mut out).unwrap(), 5);
         assert_eq!(&out[..5], b"hello");
@@ -87,7 +128,7 @@ mod tests {
         let mut mem = *b"abcdefgh";
         let h = header(0, 8);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 3];
         assert_eq!(c.read(&mut out).unwrap(), 3);
         assert_eq!(&out, b"abc");
@@ -98,7 +139,7 @@ mod tests {
         let mut mem = *b"WXYZabcd";
         let h = header(5, 12);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 8];
         assert_eq!(c.read(&mut out).unwrap(), 7);
         assert_eq!(&out[..7], b"bcdWXYZ");
@@ -109,7 +150,7 @@ mod tests {
         let mut mem = [0u8; 4];
         let h = header(4, 4);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 4];
         assert!(matches!(c.read(&mut out), Err(PipeError::WouldBlock)));
     }
@@ -119,7 +160,7 @@ mod tests {
         let mut mem = *b"data";
         let h = header(0, 4);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 0];
         assert_eq!(c.read(&mut out).unwrap(), 0);
         assert_eq!(h.read_cursor.load(Ordering::Relaxed), 0);
@@ -130,7 +171,7 @@ mod tests {
         let mut mem = [0u8; 4];
         let h = header(0, 0);
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
-        let mut c = RingConsumer::new(&h, data);
+        let mut c = RingConsumer::new(raw(&mut mem), &h, data);
         let mut out = [0u8; 0];
         assert_eq!(c.read(&mut out).unwrap(), 0);
     }

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -63,7 +63,10 @@ impl<R: SharedMemoryRegion> RingProducer<R> {
     }
 
     /// Signal that this producer will write no more bytes.
-    pub fn close_writer(&self) {
+    ///
+    /// Takes `&mut self`: there is exactly one producer, so closing is an
+    /// exclusive operation and cannot race with a concurrent write on this end.
+    pub fn close_writer(&mut self) {
         self.header().writer_closed.store(true, Ordering::Release);
     }
 
@@ -89,7 +92,7 @@ impl<R: SharedMemoryRegion> traits::Write for RingProducer<R> {
         if self.header().reader_closed.load(Ordering::Acquire) {
             return Err(PipeError::Closed);
         }
-        let free = self.header().free_space(self.data.size());
+        let free = self.header().writable_len(self.data.size());
         if free == 0 {
             return Err(PipeError::WouldBlock);
         }

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -53,13 +53,16 @@ impl<R: SharedMemoryRegion> RingProducer<R> {
         unsafe { &*self.header }
     }
 
-    /// Bytes written by this producer that the consumer has not yet read.
-    /// Uses Acquire on read_cursor so this can be called cross-thread safely.
-    pub fn bytes_pending(&self) -> u64 {
-        let header = self.header();
-        let write = header.write_cursor.load(Ordering::Relaxed);
-        let read = header.read_cursor.load(Ordering::Acquire);
-        write.wrapping_sub(read)
+    /// Bytes available to read (ring occupancy) — the producer-side counterpart
+    /// of [`RingHeader::readable_len`].
+    ///
+    /// Derived as `capacity - writable_len` rather than calling
+    /// `RingHeader::readable_len` directly, because the producer must load the
+    /// peer's `read_cursor` with Acquire (which `writable_len` does), whereas
+    /// `RingHeader::readable_len` uses the consumer-side ordering.
+    pub fn readable_len(&self) -> u64 {
+        let capacity = self.data.size();
+        capacity - self.header().writable_len(capacity)
     }
 
     /// Signal that this producer will write no more bytes.
@@ -209,32 +212,32 @@ mod tests {
     }
 
     #[test]
-    fn bytes_pending_empty() {
+    fn readable_len_empty() {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
         let p = RingProducer::new(raw(&mut mem), &h, data);
-        assert_eq!(p.bytes_pending(), 0);
+        assert_eq!(p.readable_len(), 0);
     }
 
     #[test]
-    fn bytes_pending_after_write() {
+    fn readable_len_after_write() {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
         let mut p = RingProducer::new(raw(&mut mem), &h, data);
         p.write(b"hello").unwrap();
-        assert_eq!(p.bytes_pending(), 5);
+        assert_eq!(p.readable_len(), 5);
     }
 
     #[test]
-    fn bytes_pending_zero_after_full_read() {
+    fn readable_len_zero_after_full_read() {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
         let mut p = RingProducer::new(raw(&mut mem), &h, data);
         p.write(b"hello").unwrap();
         h.read_cursor.store(5, Ordering::Release);
-        assert_eq!(p.bytes_pending(), 0);
+        assert_eq!(p.readable_len(), 0);
     }
 }

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -18,7 +18,7 @@ impl<'a> RingProducer<'a> {
     /// Uses Acquire on read_cursor so this can be called cross-thread safely.
     pub fn bytes_pending(&self) -> u64 {
         let write = self.header.write_cursor.load(Ordering::Relaxed);
-        let read  = self.header.read_cursor.load(Ordering::Acquire);
+        let read = self.header.read_cursor.load(Ordering::Acquire);
         write.wrapping_sub(read)
     }
 
@@ -41,7 +41,9 @@ impl<'a> RingProducer<'a> {
 
 impl<'a> traits::Write for RingProducer<'a> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
-        if buf.is_empty() { return Ok(0); }
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let free = self.header.free_space(self.data.size());
         if free == 0 {
             return Err(PipeError::WouldBlock);
@@ -53,7 +55,9 @@ impl<'a> traits::Write for RingProducer<'a> {
 
         // No standalone fence needed, release on the store guarantees the
         // preceding write_at is visible before the cursor update
-        self.header.write_cursor.store(cursor + n as u64, Ordering::Release);
+        self.header
+            .write_cursor
+            .store(cursor + n as u64, Ordering::Release);
         Ok(n)
     }
 }

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -80,8 +80,7 @@ impl<R: SharedMemoryRegion> RingProducer<R> {
 
     /// True when both ends of this ring are closed.
     pub fn is_closed(&self) -> bool {
-        self.header().writer_closed.load(Ordering::Acquire)
-            && self.header().reader_closed.load(Ordering::Acquire)
+        self.header().is_closed()
     }
 }
 

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -1,0 +1,170 @@
+use crate::pipe::error::PipeError;
+use crate::pipe::ring::{RingData, RingHeader};
+use crate::pipe::traits;
+use core::sync::atomic::Ordering;
+
+/// Producer (write) end of a single SPSC ring buffer.
+pub struct RingProducer<'a> {
+    header: &'a RingHeader,
+    data: RingData,
+}
+
+impl<'a> RingProducer<'a> {
+    pub fn new(header: &'a RingHeader, data: RingData) -> Self {
+        Self { header, data }
+    }
+
+    /// Bytes written by this producer that the consumer has not yet read.
+    /// Uses Acquire on read_cursor so this can be called cross-thread safely.
+    pub fn bytes_pending(&self) -> u64 {
+        let write = self.header.write_cursor.load(Ordering::Relaxed);
+        let read  = self.header.read_cursor.load(Ordering::Acquire);
+        write.wrapping_sub(read)
+    }
+
+    /// Signal that this producer will write no more bytes.
+    pub fn close_writer(&self) {
+        self.header.writer_closed.store(true, Ordering::Release);
+    }
+
+    /// True if the consumer has closed its read end.
+    pub fn is_reader_closed(&self) -> bool {
+        self.header.reader_closed.load(Ordering::Acquire)
+    }
+
+    /// True when both ends of this ring are closed.
+    pub fn is_closed(&self) -> bool {
+        self.header.writer_closed.load(Ordering::Acquire)
+            && self.header.reader_closed.load(Ordering::Acquire)
+    }
+}
+
+impl<'a> traits::Write for RingProducer<'a> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
+        if buf.is_empty() { return Ok(0); }
+        let free = self.header.free_space(self.data.size());
+        if free == 0 {
+            return Err(PipeError::WouldBlock);
+        }
+
+        let n = core::cmp::min(buf.len() as u64, free) as usize;
+        let cursor = self.header.write_cursor.load(Ordering::Relaxed);
+        self.data.write_at(cursor, &buf[..n]);
+
+        // No standalone fence needed, release on the store guarantees the
+        // preceding write_at is visible before the cursor update
+        self.header.write_cursor.store(cursor + n as u64, Ordering::Release);
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipe::traits::Write;
+    use core::sync::atomic::AtomicU64;
+
+    fn header() -> RingHeader {
+        use core::sync::atomic::AtomicBool;
+        RingHeader {
+            read_cursor: AtomicU64::new(0),
+            write_cursor: AtomicU64::new(0),
+            writer_closed: AtomicBool::new(false),
+            reader_closed: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn simple_write() {
+        let h = header();
+        let mut mem = [0u8; 16];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 16) };
+        let mut p = RingProducer::new(&h, data);
+        assert_eq!(p.write(b"hello").unwrap(), 5);
+        assert_eq!(&mem[..5], b"hello");
+        assert_eq!(h.write_cursor.load(Ordering::Relaxed), 5);
+    }
+
+    #[test]
+    fn fill_to_full() {
+        let h = header();
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        assert_eq!(p.write(b"abcdefghij").unwrap(), 8);
+        assert_eq!(&mem, b"abcdefgh");
+    }
+
+    #[test]
+    fn wrap_around() {
+        let h = header();
+        h.read_cursor.store(5, Ordering::Relaxed);
+        h.write_cursor.store(5, Ordering::Relaxed);
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        assert_eq!(p.write(b"XYZW").unwrap(), 4);
+        assert_eq!(&mem[5..8], b"XYZ");
+        assert_eq!(&mem[..1], b"W");
+    }
+
+    #[test]
+    fn full_ring_blocks() {
+        let h = header();
+        h.write_cursor.store(4, Ordering::Relaxed);
+        let mut mem = [0u8; 4];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
+        let mut p = RingProducer::new(&h, data);
+        assert!(matches!(p.write(b"x"), Err(PipeError::WouldBlock)));
+    }
+
+    #[test]
+    fn zero_length_write_non_full() {
+        let h = header();
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        assert_eq!(p.write(b"").unwrap(), 0);
+        assert_eq!(h.write_cursor.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn zero_length_write_full() {
+        let h = header();
+        h.write_cursor.store(8, Ordering::Relaxed);
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        assert_eq!(p.write(b"").unwrap(), 0);
+    }
+
+    #[test]
+    fn bytes_pending_empty() {
+        let h = header();
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let p = RingProducer::new(&h, data);
+        assert_eq!(p.bytes_pending(), 0);
+    }
+
+    #[test]
+    fn bytes_pending_after_write() {
+        let h = header();
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        p.write(b"hello").unwrap();
+        assert_eq!(p.bytes_pending(), 5);
+    }
+
+    #[test]
+    fn bytes_pending_zero_after_full_read() {
+        let h = header();
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(&h, data);
+        p.write(b"hello").unwrap();
+        h.read_cursor.store(5, Ordering::Release);
+        assert_eq!(p.bytes_pending(), 0);
+    }
+}

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -84,6 +84,11 @@ impl<R: SharedMemoryRegion> traits::Write for RingProducer<R> {
         if buf.is_empty() {
             return Ok(0);
         }
+        // Broken pipe: the reader has gone away, so no write can ever be
+        // consumed. Surface this rather than silently buffering into a dead ring.
+        if self.header().reader_closed.load(Ordering::Acquire) {
+            return Err(PipeError::Closed);
+        }
         let free = self.header().free_space(self.data.size());
         if free == 0 {
             return Err(PipeError::WouldBlock);
@@ -167,6 +172,17 @@ mod tests {
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
         let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert!(matches!(p.write(b"x"), Err(PipeError::WouldBlock)));
+    }
+
+    #[test]
+    fn write_to_reader_closed_errs() {
+        let h = header();
+        h.reader_closed.store(true, Ordering::Release);
+        let mut mem = [0u8; 8];
+        let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
+        // Reader gone: broken pipe, not a transient WouldBlock.
+        assert!(matches!(p.write(b"x"), Err(PipeError::Closed)));
     }
 
     #[test]

--- a/common/src/pipe/ring_producer.rs
+++ b/common/src/pipe/ring_producer.rs
@@ -1,61 +1,101 @@
 use crate::pipe::error::PipeError;
 use crate::pipe::ring::{RingData, RingHeader};
+use crate::pipe::shared_memory_region::SharedMemoryRegion;
 use crate::pipe::traits;
 use core::sync::atomic::Ordering;
 
 /// Producer (write) end of a single SPSC ring buffer.
-pub struct RingProducer<'a> {
-    header: &'a RingHeader,
+///
+/// Owns its own clone of the [`SharedMemoryRegion`] handle, so it keeps the
+/// shared mapping alive independently and carries no lifetime. Combined with
+/// the raw header pointer (rather than a borrow), this makes the producer a
+/// self-contained, movable, `Send` value — exactly what
+/// [`BidirectionalPipe::split`] hands back.
+///
+/// [`SharedMemoryRegion`]: crate::pipe::shared_memory_region::SharedMemoryRegion
+/// [`BidirectionalPipe::split`]: crate::pipe::bidirectional_pipe::BidirectionalPipe::split
+pub struct RingProducer<R: SharedMemoryRegion> {
+    /// Liveness only: keeps the mapped bytes alive for as long as this end exists.
+    ///
+    /// Drop order is safe regardless of field position: `header`/`data` are raw
+    /// pointers with no-op drops that never dereference the region, so dropping
+    /// `region` (which may unmap the memory for an mmap-backed `R`) cannot cause
+    /// a use-after-free.
+    #[allow(dead_code)]
+    region: R,
+    header: *const RingHeader,
     data: RingData,
 }
 
-impl<'a> RingProducer<'a> {
-    pub fn new(header: &'a RingHeader, data: RingData) -> Self {
-        Self { header, data }
+// SAFETY: the producer owns the sole write cursor of an SPSC ring. The raw
+// pointers address shared memory whose liveness is guaranteed by the owned
+// region handle; SPSC discipline guarantees there is never more than one
+// producer, so moving it to another thread (when `R: Send`) cannot introduce a
+// data race.
+unsafe impl<R: SharedMemoryRegion + Send> Send for RingProducer<R> {}
+
+impl<R: SharedMemoryRegion> RingProducer<R> {
+    pub fn new(region: R, header: *const RingHeader, data: RingData) -> Self {
+        Self {
+            region,
+            header,
+            data,
+        }
+    }
+
+    /// Access the ring header living in shared memory.
+    ///
+    /// Borrows are deliberately kept short-lived (never held across a mutation
+    /// of `data`) so this stays sound with `&mut self` ring operations.
+    fn header(&self) -> &RingHeader {
+        // SAFETY: see the struct docs — the pointer was derived from a valid,
+        // correctly-aligned shared region and stays valid for our lifetime.
+        unsafe { &*self.header }
     }
 
     /// Bytes written by this producer that the consumer has not yet read.
     /// Uses Acquire on read_cursor so this can be called cross-thread safely.
     pub fn bytes_pending(&self) -> u64 {
-        let write = self.header.write_cursor.load(Ordering::Relaxed);
-        let read = self.header.read_cursor.load(Ordering::Acquire);
+        let header = self.header();
+        let write = header.write_cursor.load(Ordering::Relaxed);
+        let read = header.read_cursor.load(Ordering::Acquire);
         write.wrapping_sub(read)
     }
 
     /// Signal that this producer will write no more bytes.
     pub fn close_writer(&self) {
-        self.header.writer_closed.store(true, Ordering::Release);
+        self.header().writer_closed.store(true, Ordering::Release);
     }
 
     /// True if the consumer has closed its read end.
     pub fn is_reader_closed(&self) -> bool {
-        self.header.reader_closed.load(Ordering::Acquire)
+        self.header().reader_closed.load(Ordering::Acquire)
     }
 
     /// True when both ends of this ring are closed.
     pub fn is_closed(&self) -> bool {
-        self.header.writer_closed.load(Ordering::Acquire)
-            && self.header.reader_closed.load(Ordering::Acquire)
+        self.header().writer_closed.load(Ordering::Acquire)
+            && self.header().reader_closed.load(Ordering::Acquire)
     }
 }
 
-impl<'a> traits::Write for RingProducer<'a> {
+impl<R: SharedMemoryRegion> traits::Write for RingProducer<R> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError> {
         if buf.is_empty() {
             return Ok(0);
         }
-        let free = self.header.free_space(self.data.size());
+        let free = self.header().free_space(self.data.size());
         if free == 0 {
             return Err(PipeError::WouldBlock);
         }
 
         let n = core::cmp::min(buf.len() as u64, free) as usize;
-        let cursor = self.header.write_cursor.load(Ordering::Relaxed);
+        let cursor = self.header().write_cursor.load(Ordering::Relaxed);
         self.data.write_at(cursor, &buf[..n]);
 
         // No standalone fence needed, release on the store guarantees the
         // preceding write_at is visible before the cursor update
-        self.header
+        self.header()
             .write_cursor
             .store(cursor + n as u64, Ordering::Release);
         Ok(n)
@@ -65,8 +105,15 @@ impl<'a> traits::Write for RingProducer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipe::shared_memory_region::RawSharedMemoryRegion;
     use crate::pipe::traits::Write;
     use core::sync::atomic::AtomicU64;
+
+    /// Region handle for tests. Only needed to satisfy ownership/liveness — the
+    /// ring's actual header/data pointers are supplied separately below.
+    fn raw(mem: &mut [u8]) -> RawSharedMemoryRegion {
+        unsafe { RawSharedMemoryRegion::from_raw(mem.as_mut_ptr(), mem.len() as u64) }
+    }
 
     fn header() -> RingHeader {
         use core::sync::atomic::AtomicBool;
@@ -83,7 +130,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 16];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 16) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.write(b"hello").unwrap(), 5);
         assert_eq!(&mem[..5], b"hello");
         assert_eq!(h.write_cursor.load(Ordering::Relaxed), 5);
@@ -94,7 +141,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.write(b"abcdefghij").unwrap(), 8);
         assert_eq!(&mem, b"abcdefgh");
     }
@@ -106,7 +153,7 @@ mod tests {
         h.write_cursor.store(5, Ordering::Relaxed);
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.write(b"XYZW").unwrap(), 4);
         assert_eq!(&mem[5..8], b"XYZ");
         assert_eq!(&mem[..1], b"W");
@@ -118,7 +165,7 @@ mod tests {
         h.write_cursor.store(4, Ordering::Relaxed);
         let mut mem = [0u8; 4];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 4) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert!(matches!(p.write(b"x"), Err(PipeError::WouldBlock)));
     }
 
@@ -127,7 +174,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.write(b"").unwrap(), 0);
         assert_eq!(h.write_cursor.load(Ordering::Relaxed), 0);
     }
@@ -138,7 +185,7 @@ mod tests {
         h.write_cursor.store(8, Ordering::Relaxed);
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.write(b"").unwrap(), 0);
     }
 
@@ -147,7 +194,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let p = RingProducer::new(&h, data);
+        let p = RingProducer::new(raw(&mut mem), &h, data);
         assert_eq!(p.bytes_pending(), 0);
     }
 
@@ -156,7 +203,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         p.write(b"hello").unwrap();
         assert_eq!(p.bytes_pending(), 5);
     }
@@ -166,7 +213,7 @@ mod tests {
         let h = header();
         let mut mem = [0u8; 8];
         let data = unsafe { RingData::new(mem.as_mut_ptr(), 8) };
-        let mut p = RingProducer::new(&h, data);
+        let mut p = RingProducer::new(raw(&mut mem), &h, data);
         p.write(b"hello").unwrap();
         h.read_cursor.store(5, Ordering::Release);
         assert_eq!(p.bytes_pending(), 0);

--- a/common/src/pipe/shared_memory_region.rs
+++ b/common/src/pipe/shared_memory_region.rs
@@ -1,0 +1,66 @@
+/// Owns a reference to a shared memory region.
+///
+/// Instead of exposing raw pointers and `unsafe` at every call site, we wrap
+/// the shared memory region in a type that guarantees validity — pushing the
+/// `unsafe` into a single place. After constructing a `SharedMemoryRegion`,
+/// all pipe construction and usage is safe.
+///
+/// How the shared memory pointer is obtained (hypervisor mapping, POSIX shm,
+/// etc.) is outside this type's scope — we assume both sides have a way to
+/// get it.
+pub struct SharedMemoryRegion {
+    ptr: *mut u8,
+    len: u64,
+}
+
+impl SharedMemoryRegion {
+    /// Create a new shared memory region from a raw pointer.
+    ///
+    /// This is the one and only unsafe entry point for the pipe library.
+    ///
+    /// # Safety
+    /// - `ptr` must point to a valid, read-write memory region of at least `len` bytes.
+    /// - The memory must remain valid for the lifetime of this `SharedMemoryRegion`.
+    /// - The memory must be shared between both sides of the pipe (e.g. via
+    ///   hypervisor page mapping or POSIX shared memory).
+    /// - The memory must be zero-initialized before the first pipe is created from it.
+    pub unsafe fn from_raw(ptr: *mut u8, len: u64) -> Self {
+        Self { ptr, len }
+    }
+
+    /// Returns a raw pointer to the start of the shared memory region.
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Returns the length of the shared memory region in bytes.
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Returns true if the shared memory region has zero length.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_raw_stores_ptr_and_len() {
+        let mut buf = [0u8; 16];
+        let region = unsafe { SharedMemoryRegion::from_raw(buf.as_mut_ptr(), buf.len() as u64) };
+        assert_eq!(region.as_ptr(), buf.as_mut_ptr());
+        assert_eq!(region.len(), 16);
+        assert!(!region.is_empty());
+    }
+
+    #[test]
+    fn zero_length_is_empty() {
+        let region = unsafe { SharedMemoryRegion::from_raw(core::ptr::null_mut(), 0) };
+        assert_eq!(region.len(), 0);
+        assert!(region.is_empty());
+    }
+}

--- a/common/src/pipe/shared_memory_region.rs
+++ b/common/src/pipe/shared_memory_region.rs
@@ -1,46 +1,83 @@
-/// Owns a reference to a shared memory region.
+//! Shared memory region abstraction for pipe endpoints.
+
+/// A cheap, cloneable handle to a shared memory region mapped into both pipe
+/// endpoints' address spaces.
 ///
-/// Instead of exposing raw pointers and `unsafe` at every call site, we wrap
-/// the shared memory region in a type that guarantees validity — pushing the
-/// `unsafe` into a single place. After constructing a `SharedMemoryRegion`,
-/// all pipe construction and usage is safe.
+/// This is a *handle*, not necessarily an owner in the RAII sense — cloning
+/// yields another handle to the *same* underlying bytes. How the region is
+/// mapped (hypervisor page, POSIX shm, `mmap`) and whether dropping the last
+/// handle unmaps it is the concrete implementation's concern.
 ///
-/// How the shared memory pointer is obtained (hypervisor mapping, POSIX shm,
-/// etc.) is outside this type's scope — we assume both sides have a way to
-/// get it.
-pub struct SharedMemoryRegion {
+/// The trait requires [`Clone`] so each half of a split pipe (see
+/// [`super::bidirectional_pipe`]) can own its own handle and keep the mapping
+/// alive independently — this is what lets the pipe carry no lifetime.
+pub trait SharedMemoryRegion: Clone {
+    /// Pointer to the start of the region. Valid for at least [`len`](Self::len) bytes.
+    ///
+    /// # Safety contract for implementors
+    /// Pipe ends cache this pointer for their whole lifetime, so an
+    /// implementation MUST guarantee that the returned address points to the
+    /// same allocation — valid for at least `len()` bytes of reads/writes — for
+    /// as long as *any* handle (the original or any clone) is alive. An `R` that
+    /// relocates or invalidates the backing memory while a handle lives (e.g. a
+    /// clone that re-maps to a new address) makes the ring ends' raw pointers
+    /// dangling and is unsound.
+    fn as_ptr(&self) -> *mut u8;
+
+    /// Length of the region in bytes.
+    fn len(&self) -> u64;
+
+    /// True if the region has zero length.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// A [`SharedMemoryRegion`] that is nothing but a raw `(ptr, len)` pair with no
+/// ownership semantics: dropping it does nothing.
+///
+/// This is the Arca-side / test implementation — the memory is mapped by the
+/// hypervisor and is never unmapped by this type, so cloning (a plain `Copy`)
+/// is free. The host (vmm) side can provide a different implementation backed
+/// by an `mmap`/`Arc` handle that manages unmapping on drop of the last clone.
+#[derive(Clone, Copy)]
+pub struct RawSharedMemoryRegion {
     ptr: *mut u8,
     len: u64,
 }
 
-impl SharedMemoryRegion {
-    /// Create a new shared memory region from a raw pointer.
+// SAFETY: `RawSharedMemoryRegion` is a bare address + length into memory that is
+// intentionally shared across threads/address spaces. It carries no ownership,
+// so moving or sharing the handle itself is sound; correct concurrent *access*
+// to the bytes is enforced by the SPSC ring discipline layered on top, not by
+// this handle.
+unsafe impl Send for RawSharedMemoryRegion {}
+unsafe impl Sync for RawSharedMemoryRegion {}
+
+impl RawSharedMemoryRegion {
+    /// Create a region handle from a raw pointer.
     ///
     /// This is the one and only unsafe entry point for the pipe library.
     ///
     /// # Safety
-    /// - `ptr` must point to a valid, read-write memory region of at least `len` bytes.
-    /// - The memory must remain valid for the lifetime of this `SharedMemoryRegion`.
+    /// - `ptr` must point to a valid, read-write region of at least `len` bytes.
+    /// - The memory must remain valid for as long as any handle (or any pipe /
+    ///   pipe-half derived from it) is alive.
     /// - The memory must be shared between both sides of the pipe (e.g. via
     ///   hypervisor page mapping or POSIX shared memory).
     /// - The memory must be zero-initialized before the first pipe is created from it.
     pub unsafe fn from_raw(ptr: *mut u8, len: u64) -> Self {
         Self { ptr, len }
     }
+}
 
-    /// Returns a raw pointer to the start of the shared memory region.
-    pub fn as_ptr(&self) -> *mut u8 {
+impl SharedMemoryRegion for RawSharedMemoryRegion {
+    fn as_ptr(&self) -> *mut u8 {
         self.ptr
     }
 
-    /// Returns the length of the shared memory region in bytes.
-    pub fn len(&self) -> u64 {
+    fn len(&self) -> u64 {
         self.len
-    }
-
-    /// Returns true if the shared memory region has zero length.
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
     }
 }
 
@@ -51,7 +88,7 @@ mod tests {
     #[test]
     fn from_raw_stores_ptr_and_len() {
         let mut buf = [0u8; 16];
-        let region = unsafe { SharedMemoryRegion::from_raw(buf.as_mut_ptr(), buf.len() as u64) };
+        let region = unsafe { RawSharedMemoryRegion::from_raw(buf.as_mut_ptr(), buf.len() as u64) };
         assert_eq!(region.as_ptr(), buf.as_mut_ptr());
         assert_eq!(region.len(), 16);
         assert!(!region.is_empty());
@@ -59,8 +96,17 @@ mod tests {
 
     #[test]
     fn zero_length_is_empty() {
-        let region = unsafe { SharedMemoryRegion::from_raw(core::ptr::null_mut(), 0) };
+        let region = unsafe { RawSharedMemoryRegion::from_raw(core::ptr::null_mut(), 0) };
         assert_eq!(region.len(), 0);
         assert!(region.is_empty());
+    }
+
+    #[test]
+    fn clone_points_to_same_memory() {
+        let mut buf = [0u8; 8];
+        let a = unsafe { RawSharedMemoryRegion::from_raw(buf.as_mut_ptr(), 8) };
+        let b = a; // Copy handle — clone points at the same bytes
+        assert_eq!(a.as_ptr(), b.as_ptr());
+        assert_eq!(a.len(), b.len());
     }
 }

--- a/common/src/pipe/traits.rs
+++ b/common/src/pipe/traits.rs
@@ -23,13 +23,17 @@ pub trait Write {
     /// or `Err(WouldBlock)` if the ring is currently full.
     fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError>;
 
-    /// Write all bytes in `src`, spinning on `WouldBlock` until every byte is written.
-    fn write_all(&mut self, mut src: &[u8]) {
+    /// Write all bytes in `src`, spinning on `WouldBlock` until every byte is
+    /// written. Returns `Err(Closed)` if the reader closes before all bytes are
+    /// written (some bytes may already have been written).
+    fn write_all(&mut self, mut src: &[u8]) -> Result<(), PipeError> {
         while !src.is_empty() {
             match self.write(src) {
                 Ok(n) => src = &src[n..],
                 Err(PipeError::WouldBlock) => core::hint::spin_loop(),
+                Err(PipeError::Closed) => return Err(PipeError::Closed),
             }
         }
+        Ok(())
     }
 }

--- a/common/src/pipe/traits.rs
+++ b/common/src/pipe/traits.rs
@@ -37,3 +37,8 @@ pub trait Write {
         Ok(())
     }
 }
+
+#[allow(unused)]
+pub trait OwnedSplit {
+    fn split(self) -> (impl Read + Send + 'static, impl Write + Send + 'static);
+}

--- a/common/src/pipe/traits.rs
+++ b/common/src/pipe/traits.rs
@@ -1,0 +1,35 @@
+use crate::pipe::error::PipeError;
+
+/// Read bytes from a pipe. Analogous to std::io::Read.
+///
+/// Partial reads are normal — `read` may return fewer bytes than `buf.len()`.
+/// The caller loops if it needs more. This matches `std::io` semantics.
+pub trait Read {
+    /// Try to read bytes into `buf`.
+    ///
+    /// Returns `Ok(n)` where `n > 0` is the number of bytes read,
+    /// or `Err(WouldBlock)` if no data is currently available.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError>;
+}
+
+/// Write bytes to a pipe. Analogous to std::io::Write.
+///
+/// Partial writes are normal — `write` may accept fewer bytes than `buf.len()`.
+/// The caller loops if it needs to write more. This matches `std::io` semantics.
+pub trait Write {
+    /// Try to write bytes from `buf`.
+    ///
+    /// Returns `Ok(n)` where `n > 0` is the number of bytes written,
+    /// or `Err(WouldBlock)` if the ring is currently full.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PipeError>;
+
+    /// Write all bytes in `src`, spinning on `WouldBlock` until every byte is written.
+    fn write_all(&mut self, mut src: &[u8]) {
+        while !src.is_empty() {
+            match self.write(src) {
+                Ok(n) => src = &src[n..],
+                Err(PipeError::WouldBlock) => core::hint::spin_loop(),
+            }
+        }
+    }
+}

--- a/common/src/sync_stream.rs
+++ b/common/src/sync_stream.rs
@@ -1,0 +1,164 @@
+use crate::pipe::{BidirectionalPipe, PipeError, Read, SharedMemoryRegion, Write};
+
+#[derive(Debug)]
+pub enum StreamError {
+    WriteClosed,
+}
+
+pub struct SyncStream<R: SharedMemoryRegion> {
+    pipe: BidirectionalPipe<R>,
+}
+
+impl<R: SharedMemoryRegion> SyncStream<R> {
+    pub fn from_pipe(pipe: BidirectionalPipe<R>) -> Self {
+        Self { pipe }
+    }
+
+    /// Write all of `buf` into the pipe, spinning if the ring is full; returns `Err(WriteClosed)` if the peer closed their read side.
+    pub fn send(&mut self, buf: &[u8]) -> Result<usize, StreamError> {
+        if self.pipe.is_peer_read_closed() {
+            self.pipe.close_write();
+            return Err(StreamError::WriteClosed);
+        }
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        match self.pipe.write_all(buf) {
+            Ok(()) => Ok(buf.len()),
+            Err(PipeError::Closed) => Err(StreamError::WriteClosed),
+            // `write_all` only ever surfaces `Closed`; it spins internally on `WouldBlock`.
+            Err(PipeError::WouldBlock) => Err(StreamError::WriteClosed),
+        }
+    }
+
+    /// Read exactly `buf.len()` bytes, spinning until full; returns `Ok(n < buf.len())` only on EOF when the peer closed their write side.
+    pub fn recv(&mut self, buf: &mut [u8]) -> Result<usize, StreamError> {
+        let n = read_exact(&mut self.pipe, buf);
+        if n < buf.len() {
+            self.pipe.close_read();
+        }
+        Ok(n)
+    }
+
+    pub fn close_write(&mut self) {
+        self.pipe.close_write();
+    }
+
+    pub fn close_read(&mut self) {
+        self.pipe.close_read();
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.pipe.is_closed()
+    }
+}
+
+fn read_exact<R: SharedMemoryRegion>(pipe: &mut BidirectionalPipe<R>, buf: &mut [u8]) -> usize {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match pipe.read(&mut buf[filled..]) {
+            // EOF: ring drained and the peer closed its write side.
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            // Empty but peer still writing — spin until data or EOF.
+            Err(PipeError::WouldBlock) => core::hint::spin_loop(),
+            // The reader never observes `Closed`; treat defensively as EOF.
+            Err(PipeError::Closed) => break,
+        }
+    }
+    filled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipe::{BidirectionalPipe, RawSharedMemoryRegion, Side};
+
+    #[repr(align(8))]
+    struct Aligned<const N: usize>([u8; N]);
+
+    macro_rules! stream_pair {
+        ($ring:expr, $mem:ident, $a:ident, $b:ident) => {
+            let mut $mem = Aligned(
+                [0u8; BidirectionalPipe::<RawSharedMemoryRegion>::required_size($ring as u64)
+                    as usize],
+            );
+            // A `RawSharedMemoryRegion` is a `Copy` handle, so each side gets its
+            // own owned clone pointing at the same backing bytes.
+            let region = unsafe {
+                RawSharedMemoryRegion::from_raw($mem.0.as_mut_ptr(), $mem.0.len() as u64)
+            };
+            let pipe_a = BidirectionalPipe::new(region, $ring, Side::A);
+            let pipe_b = BidirectionalPipe::new(region, $ring, Side::B);
+            let mut $a = SyncStream::from_pipe(pipe_a);
+            let mut $b = SyncStream::from_pipe(pipe_b);
+        };
+    }
+
+    #[test]
+    fn send_recv_data() {
+        stream_pair!(128, mem, a, b);
+        assert_eq!(a.send(b"hello").unwrap(), 5);
+        let mut buf = [0u8; 5];
+        assert_eq!(b.recv(&mut buf).unwrap(), 5);
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[test]
+    fn close_write_signals_eof_to_peer() {
+        stream_pair!(64, mem, a, b);
+        a.close_write();
+        let mut buf = [0u8; 8];
+        assert_eq!(b.recv(&mut buf).unwrap(), 0);
+        assert!(!b.is_closed());
+    }
+
+    #[test]
+    fn close_both_sides_blocks_peer_ops() {
+        stream_pair!(64, mem, a, b);
+        b.close_write();
+        b.close_read();
+        // b has closed its own ends but a hasn't yet — pipe not fully closed
+        assert!(!b.is_closed());
+        let mut buf = [0u8; 8];
+        // a sees EOF because b closed write, and WriteClosed because b closed read
+        assert_eq!(a.recv(&mut buf).unwrap(), 0);
+        assert!(matches!(a.send(b"x"), Err(StreamError::WriteClosed)));
+    }
+
+    #[test]
+    fn send_after_peer_closes_read_errors() {
+        stream_pair!(64, mem, a, b);
+        b.close_read();
+        assert!(matches!(a.send(b"x"), Err(StreamError::WriteClosed)));
+    }
+
+    #[test]
+    fn recv_after_eof_returns_zero() {
+        stream_pair!(64, mem, a, b);
+        a.close_write();
+        let mut buf = [0u8; 8];
+        b.recv(&mut buf).unwrap();
+        assert_eq!(b.recv(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn recv_fills_exact_buffer_size() {
+        stream_pair!(128, mem, a, b);
+        assert_eq!(a.send(b"hello").unwrap(), 5);
+        let mut buf = [0u8; 5];
+        assert_eq!(b.recv(&mut buf).unwrap(), 5);
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[test]
+    fn pipe_closed_after_both_sides_close() {
+        stream_pair!(128, mem, a, b);
+        a.close_write();
+        let mut buf = [0u8; 8];
+        b.recv(&mut buf).unwrap();
+        b.close_write();
+        a.recv(&mut buf).unwrap();
+        assert!(a.is_closed());
+    }
+}


### PR DESCRIPTION
This PR adds a `no_std` bidirectional pipe implementation shared by vmm-side and Arca-side